### PR TITLE
docs: archive settings tests todo

### DIFF
--- a/docs/todo/archive/20251005-rules-branding-tests.md
+++ b/docs/todo/archive/20251005-rules-branding-tests.md
@@ -1,0 +1,31 @@
+---
+目的: 設定ファイルのローディングに対するユニットテストを整備し、破壊的変更を早期検知する
+担当者: Codex
+関連ブランチ: feat/2-rules-branding-tests
+期限: 2025-10-12
+関連Issue: #3
+関連PR: #4
+closed_at: 2025-10-05
+---
+
+- [x] ブランチを作成し、正式ブランチ名の計画を固める
+  - メモ: 暫定ブランチから `feat/2-rules-branding-tests` にリネーム済み
+- [x] `RulesConfig.load` の正常系と境界値テストを追加する
+  - メモ: 正常系・デフォルトフォールバックを `tests/test_settings.py` で検証
+- [x] `RulesConfig.load` の異常系テストを追加する
+  - メモ: 破損 JSON で `json.JSONDecodeError` を確認
+- [x] `BrandingConfig.load` の正常系とフォールバックテストを追加する
+  - メモ: カラーコード補完とフォールバックを `tests/test_settings.py` で検証
+- [x] `BrandingConfig.load` の異常系テストを追加する
+  - メモ: 破損 JSON で `json.JSONDecodeError` を確認
+- [x] 新設テストを `uv run --extra dev pytest tests/test_settings.py` で実行し結果を記録する
+  - メモ: 2025-10-05 すべて成功
+- [x] Issue 作成
+  - メモ: Issue #3 を作成済み
+- [x] PR 作成
+  - メモ: PR #4 を作成済み
+
+## メモ
+- ブランチパターン: ToDo 先行。暫定ブランチ `docs/todo-rules-branding-tests` で開始し、Issue #2 と連携後に正式ブランチへ切り替える。
+- 設定ファイル: `config/rules.json`, `config/branding.json` をモックファイルで覆う必要あり。
+- 全体テスト: `uv run --extra dev pytest` で既存ケースに影響がないことを確認済み。


### PR DESCRIPTION
## 概要
- 設定テスト用 ToDo (`20251005-rules-branding-tests.md`) を `docs/todo/archive/` へ移動
- 完了日時 `closed_at: 2025-10-05` や Issue/PR 情報を記録

## 関連リンク
- ToDo: docs/todo/archive/20251005-rules-branding-tests.md
- PR: #4
- Issue: #3

## 変更内容
- 完了済み ToDo のヘッダに関連 Issue / PR / closed_at を整備
- `docs/todo/` から当該ファイルを削除しアーカイブへ移動

## 動作確認
- [x] ドキュメントのみのため未実施

## チェックリスト
- [x] ToDo のチェックボックスを最新化した
- [x] Issue に進捗コメント（またはクローズコメント）を残した
- [x] 影響範囲を確認し、必要なドキュメントを更新した
