### PR TITLE
fix: update template references after consolidation

### DIFF
--- a/docs/notes/20251009-placeholder-anchor-design.md
+++ b/docs/notes/20251009-placeholder-anchor-design.md
@@ -1,12 +1,12 @@
 # プレースホルダーアンカー拡張検討メモ（2025-10-09）
 
 ## 背景
-- `samples/templates/templates2.pptx` などのレイアウトでは、`Body Left` や `Logo` といったアンカー候補がプレースホルダーとして定義されている。
+- `samples/templates/templates.pptx` などのレイアウトでは、`Body Left` や `Logo` といったアンカー候補がプレースホルダーとして定義されている。
 - 現行レンダラーは図形名検索で見つからない場合にプレースホルダー名をレイアウトから逆引きしているが、取得したプレースホルダーに対して `insert_picture` / `insert_chart` を呼び出す前提になっている。
 - PowerPoint の汎用プレースホルダー（`PP_PLACEHOLDER.OBJECT` など）は `python-pptx` 上で `insert_*` メソッドを持たず、レンダリング時に `AttributeError` が発生してフォールバック座標での描画、もしくは処理失敗に繋がる。
 
 ## 調査結果
-- `samples/templates/templates2.pptx` の `Two Column Detail` レイアウト:
+- `samples/templates/templates.pptx` の `Two Column Detail` レイアウト:
   - `Body Left` / `Body Right` / `Logo` はいずれも `PP_PLACEHOLDER.OBJECT`。`SlidePlaceholder.insert_picture` / `insert_chart` は実装されていなかった。
   - プレースホルダーの `placeholder_format.idx` を使えばスライド作成後に名称が `Content Placeholder n` へ変わっても追跡できる。
 - 汎用プレースホルダーに対しては `slide.shapes.add_*` で図形を追加し、座標・サイズをプレースホルダーから転写するのが安定。

--- a/docs/todo/archive/20251009-placeholder-anchor.md
+++ b/docs/todo/archive/20251009-placeholder-anchor.md
@@ -17,6 +17,6 @@ roadmap_item: RM-008 カスタムテンプレート操作性向上
 ## メモ
 - 現状は図形名だけがアンカーに使われるため、プレースホルダーを利用した柔軟なレイアウトが難しい。
 - プレースホルダーの名称はスライド生成後に既定名へ変換される可能性があるため、ID ベースでの追跡やレイアウト段階でのメタデータ保持が必要。
-- 再現例: `samples/sample_spec.json` の `metric-chart` で `"anchor": "Body Left"` を指定し、`uv run pptx-generator run samples/sample_spec.json --template samples/templates/templates2.pptx --workdir .pptxgen/full3` を実行すると、Two Column Detail レイアウトのプレースホルダーが `Content Placeholder 2` へ変換され、チャートがフォールバック位置に挿入される。
+- 再現例: `samples/sample_spec.json` の `"anchor": "Body Left"` を指定し、`uv run pptx-generator run samples/sample_spec.json --template samples/templates/templates.pptx --workdir .pptxgen/full3` を実行すると、Two Column Detail レイアウトのプレースホルダーが `Content Placeholder 2` へ変換され、チャートがフォールバック位置に挿入される。
 - 設計メモ: `docs/notes/20251009-placeholder-anchor-design.md`
 - 実行環境メモ: `UV_CACHE_DIR=.uv-cache` を付けるとサンドボックス環境でも `uv run` 系が動作しやすい。

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -679,7 +679,7 @@ def test_renderer_fallback_when_placeholder_renamed(tmp_path: Path, caplog) -> N
 
 
 def test_renderer_handles_object_placeholders(tmp_path: Path) -> None:
-    template_path = Path("samples/templates/templates2.pptx")
+    template_path = Path("samples/templates/templates.pptx")
     placeholders = _load_placeholder_boxes(template_path, "Two Column Detail")
     assert (
         "Body Left" in placeholders


### PR DESCRIPTION
## 概要
- テンプレート統合後に残っていた `samples/templates/templates2.pptx` 参照を `templates.pptx` へ統一しました。
- ドキュメント内の再現手順／設計メモを最新テンプレートに合わせて更新しました。

## 関連リンク
- Close: なし
- Issue: なし
- ToDo: docs/todo/20251009-placeholder-anchor.md
- ノート／設計資料: docs/notes/20251009-placeholder-anchor-design.md

## 変更内容
- `tests/test_renderer.py` のテンプレート参照を更新
- placeholder anchor のドキュメント類を現行テンプレート名に合わせて修正

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest tests/test_renderer.py`
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法:
- [ ] 必要なレビュー観点を満たしている

## チェックリスト
- [x] 該当 ToDo のチェックボックスとメモを最新化した
- [ ] ロードマップ（docs/roadmap/README.md）が最新状態になっている
- [ ] Issue 自動クローズ用に `Close #<番号>` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した
- [ ] 生成物（PDF など）がある場合は添付または参照先を明記した
- [x] PR 本文の ToDo パスを実際の `docs/todo/YYYYMMDD-<slug>.md` に置き換えた
