### PR TITLE
fix: guard draft updates for locked slides

### DIFF
--- a/tests/test_draft_store.py
+++ b/tests/test_draft_store.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 import pytest
 
-from pptx_generator.api.draft_store import DraftStore, RevisionMismatchError
+from pptx_generator.api.draft_store import (DraftStore, RevisionMismatchError,
+                                            SlideLockedError)
 from pptx_generator.models import (DraftDocument, DraftLayoutCandidate,
                                    DraftMeta, DraftSection, DraftSlideCard)
 
@@ -117,3 +118,57 @@ def test_revision_mismatch(tmp_path: Path, draft_board: DraftDocument) -> None:
             expected_etag='W/"draft-999"',
             actor=None,
         )
+
+
+def test_locked_slide_rejects_updates(tmp_path: Path, draft_board: DraftDocument) -> None:
+    store = DraftStore(base_dir=tmp_path)
+    etag = store.create_board("spec-3", draft_board)
+
+    etag = store.approve_section(
+        spec_id="spec-3",
+        section_name="Section A",
+        expected_etag=etag,
+        actor="approver",
+        notes="ok",
+    )
+
+    with pytest.raises(SlideLockedError):
+        store.update_layout_hint(
+            spec_id="spec-3",
+            slide_id="s1",
+            layout_hint="Locked",  # 変更されない想定
+            notes=None,
+            expected_etag=etag,
+            actor="editor",
+        )
+
+    with pytest.raises(SlideLockedError):
+        store.move_slide(
+            spec_id="spec-3",
+            slide_id="s1",
+            target_section="Section B",
+            position=1,
+            expected_etag=etag,
+            actor="editor",
+        )
+
+    with pytest.raises(SlideLockedError):
+        store.set_appendix(
+            spec_id="spec-3",
+            slide_id="s1",
+            appendix=True,
+            expected_etag=etag,
+            actor="editor",
+            notes=None,
+        )
+
+    board, current_etag = store.get_board("spec-3")
+    assert current_etag == etag
+    section_a = next(section for section in board.sections if section.name == "Section A")
+    target_slide = next(slide for slide in section_a.slides if slide.ref_id == "s1")
+    assert target_slide.layout_hint == "Title"
+    assert target_slide.appendix is False
+
+    logs, next_offset = store.list_logs("spec-3", limit=10, offset=0)
+    assert len(logs) == 1
+    assert next_offset is None


### PR DESCRIPTION
## Summary
- prevent layout, move, and appendix updates when the target slide is locked
- introduce SlideLockedError for API consumers and extend unit tests for locked slide handling

## Testing
- PYTHONPATH=src pytest tests/test_draft_store.py *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68f1eb5f97408328a022c88b02307274