### PR TITLE
docs: issue テンプレートを追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+name: "バグ報告"
+description: "不具合の内容と再現手順を報告する"
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### 事前確認
+        以下の項目を確認した上で記入してください。
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: 必須チェック
+      options:
+        - label: 同じ内容の Issue が存在しないことを確認しました。
+          required: true
+        - label: 最新の `main` ブランチで再現することを確認しました。
+          required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: 概要
+      description: 発生している不具合の概要を記載してください。
+      placeholder: 例）PPTX 生成時に ValueError が発生する
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: 再現手順
+      description: 不具合を再現するための手順を番号付きで記載してください。
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待される結果
+      description: 本来期待している挙動を記載してください。
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: 実際の結果
+      description: 実際に発生した挙動やエラーメッセージを記載してください。
+    validations:
+      required: true
+  - type: textarea
+    id: env
+    attributes:
+      label: 実行環境
+      description: OS、Python バージョン、LibreOffice バージョンなど関連する情報を記載してください。
+      placeholder: |
+        - OS: 
+        - Python: 
+        - LibreOffice: 
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: 追加情報
+      description: ログやスクリーンショットなど、調査に役立つ情報があれば添付してください。
+      placeholder: 例）エラーログ、生成物、スクリーンショットなど
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,68 @@
+name: "機能改善・新機能の提案"
+description: "新しい機能の追加や改善要望を報告する"
+title: "[Feature] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### 事前確認
+        以下の項目を確認した上で記入してください。
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: 必須チェック
+      options:
+        - label: 同じ内容の Issue が存在しないことを確認しました。
+          required: true
+        - label: 既存のドキュメントや設定で代替できないことを確認しました。
+          required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: 提案内容
+      description: 追加・改善したい機能の概要を記載してください。
+      placeholder: 例）画像差し替え機能で PNG 以外の形式に対応したい
+    validations:
+      required: true
+  - type: textarea
+    id: background
+    attributes:
+      label: 背景・課題
+      description: なぜこの提案が必要なのか、背景や課題を記載してください。
+      placeholder: 例）顧客向けテンプレートで JPEG の使用が必須になったため
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: 想定する解決策
+      description: 実装案や要件があれば記載してください。
+      placeholder: 例）設定ファイルで許可する拡張子を追加できるようにする
+    validations:
+      required: false
+  - type: textarea
+    id: alternative
+    attributes:
+      label: 検討した代替案
+      description: 他に試した方法や却下した案があれば記載してください。
+      placeholder: 例）LibreOffice マクロでの代替を検討したが設定変更が必要になる
+    validations:
+      required: false
+  - type: textarea
+    id: impacts
+    attributes:
+      label: 影響範囲・想定リスク
+      description: 想定している影響範囲やリスク、テスト観点があれば記載してください。
+      placeholder: 例）画像差し替え処理のテスト追加が必要
+    validations:
+      required: false
+  - type: textarea
+    id: refs
+    attributes:
+      label: 関連資料
+      description: 参考リンクや仕様書などがあれば記載してください。
+      placeholder: 例）社内仕様書リンク、関連チケット番号
+    validations:
+      required: false


### PR DESCRIPTION
## 概要
- Issue テンプレートの不足に対応し、バグ報告と機能提案のフォームを追加。

## 関連リンク
- Issue Close: なし
- ToDo: なし
- ノート／設計資料: なし

## 変更内容
- 主なコード変更
  - GitHub Issue Forms としてバグ報告・機能提案のテンプレートを追加。
- 追加したテスト
  - なし
- 更新したドキュメント
  - なし
- その他（サンプル、アセット、設定など）
  - なし

## ユーザー影響
- ユーザー視点でどういう影響変化があるか
  - Issue 登録時に必要情報を漏れなく入力できるようになる。
- その影響変化を確認する方法
  - 修正前後比較の方法: GitHub の Issue 作成画面を開く。
  - 実行コマンド: なし
  - 結果の見方: テンプレートのフォームが表示されることを確認。

## 動作確認
- [ ] ローカルで想定テストを実行した
  - 実行コマンド: なし
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: なし
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている
- [ ] Issue 自動クローズ用の記述を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した
- [x] 生成物（PDF など）がある場合は添付または参照先を明記した
- [x] PR 本文内のプレースホルダをすべて実際の値に置き換えた

------
https://chatgpt.com/codex/tasks/task_e_690a92f35f9c83288d2b55380828f106