### PR TITLE
fix: RM-084 layout metadata complexity

### DIFF
--- a/src/pptx_generator/utils/layout_metadata.py
+++ b/src/pptx_generator/utils/layout_metadata.py
@@ -333,18 +333,14 @@ def _build_element_entry(
     name = str(placeholder.get("name") or "")
     expects_text = _expects_text_input(placeholder)
 
-    segment = f"{position_label}に"
-    if size_label:
-        segment += f"{size_label}"
-    segment += label
-    if name and name != label:
-        segment += f"（{name}）"
-    if not expects_text:
-        segment += "（テキスト入力非想定）"
-
-    size_keyword = None
-    if size_label:
-        size_keyword = size_label[:-1] if size_label.endswith("の") else size_label
+    segment = _compose_element_description(
+        position_label=position_label,
+        size_label=size_label,
+        role_label=label,
+        name=name,
+        expects_text=expects_text,
+    )
+    size_keyword = _normalize_size_keyword(size_label)
 
     element_entry: dict[str, Any] = {
         "anchor": name or None,
@@ -355,13 +351,51 @@ def _build_element_entry(
         "expects_text": expects_text,
         "description": segment,
     }
-    if area_ratio is not None:
-        element_entry["area_ratio"] = round(area_ratio, 3)
+    rounded_ratio = _rounded_area_ratio(area_ratio)
+    if rounded_ratio is not None:
+        element_entry["area_ratio"] = rounded_ratio
 
-    flags = placeholder.get("flags")
-    if isinstance(flags, list) and flags:
-        element_entry["flags"] = list(flags)
+    flag_list = _extract_flags(placeholder.get("flags"))
+    if flag_list:
+        element_entry["flags"] = flag_list
     return element_entry
+
+
+def _compose_element_description(
+    *,
+    position_label: str,
+    size_label: str | None,
+    role_label: str,
+    name: str,
+    expects_text: bool,
+) -> str:
+    parts = [f"{position_label}に"]
+    if size_label:
+        parts.append(size_label)
+    parts.append(role_label)
+    if name and name != role_label:
+        parts.append(f"（{name}）")
+    if not expects_text:
+        parts.append("（テキスト入力非想定）")
+    return "".join(parts)
+
+
+def _normalize_size_keyword(size_label: str | None) -> str | None:
+    if not size_label:
+        return None
+    return size_label[:-1] if size_label.endswith("の") else size_label
+
+
+def _rounded_area_ratio(area_ratio: float | None) -> float | None:
+    if area_ratio is None:
+        return None
+    return round(area_ratio, 3)
+
+
+def _extract_flags(flags: Any) -> list[str]:
+    if not isinstance(flags, list):
+        return []
+    return [str(flag) for flag in flags if flag is not None]
 
 
 def generate_layout_description(
@@ -453,12 +487,14 @@ def _guess_type_from_name(name: str | None) -> str | None:
     return None
 
 
+_BODY_PLACEHOLDER_REASON = ("placeholder:type=body",)
+
 _DIRECT_PLACEHOLDER_RULES: dict[str, tuple[str, tuple[str, ...]]] = {
     "title": ("mark_title", ("placeholder:type=title",)),
     "subtitle": ("mark_title", ("placeholder:type=subtitle",)),
-    "body": ("mark_body", ("placeholder:type=body",)),
-    "content": ("mark_body", ("placeholder:type=body",)),
-    "text": ("mark_body", ("placeholder:type=body",)),
+    "body": ("mark_body", _BODY_PLACEHOLDER_REASON),
+    "content": ("mark_body", _BODY_PLACEHOLDER_REASON),
+    "text": ("mark_body", _BODY_PLACEHOLDER_REASON),
     "chart": ("mark_chart", ("placeholder:type=chart",)),
     "table": ("mark_table", ("placeholder:type=table",)),
     "image": ("mark_image", ("placeholder:type=image",)),

--- a/tests/utils/test_layout_metadata.py
+++ b/tests/utils/test_layout_metadata.py
@@ -1,4 +1,13 @@
-from pptx_generator.utils.layout_metadata import derive_usage_tags, generate_layout_description
+from pptx_generator.utils.layout_metadata import (
+    _compose_element_description,
+    _compose_overview_text,
+    _extract_flags,
+    _feature_labels_from_counts,
+    _normalize_size_keyword,
+    _rounded_area_ratio,
+    derive_usage_tags,
+    generate_layout_description,
+)
 
 
 def test_derive_usage_tags_detects_basic_placeholder_types() -> None:
@@ -93,3 +102,46 @@ def test_generate_layout_description_limits_elements_to_twenty() -> None:
     description = generate_layout_description("Many Items", placeholders, (9144000, 6858000))
 
     assert len(description["elements"]) == 20
+
+
+def test_feature_labels_and_overview_helpers_cover_all_categories() -> None:
+    counts = {
+        "title": 1,
+        "subtitle": 1,
+        "body": 2,
+        "table": 1,
+        "chart": 1,
+        "image": 1,
+        "media": 1,
+        "object": 1,
+        "footer": 1,
+        "notes": 1,
+    }
+
+    labels = _feature_labels_from_counts(counts)
+    assert labels == ["タイトル", "本文", "表", "チャート", "ビジュアル", "フッター", "ノート"]
+    overview = _compose_overview_text("Layout", 3, labels)
+    assert overview.startswith("Layout レイアウトは タイトル、本文、表、チャート、ビジュアル、フッター、ノート")
+    assert _compose_overview_text("Layout", 3, []) == "Layout レイアウトは 3 個のプレースホルダーを備えています。"
+
+
+def test_element_description_and_helpers_variations() -> None:
+    description = _compose_element_description(
+        position_label="中央",
+        size_label="大きめの",
+        role_label="本文枠",
+        name="Body Main",
+        expects_text=False,
+    )
+    assert "Body Main" in description
+    assert "テキスト入力非想定" in description
+
+    assert _normalize_size_keyword("大きめの") == "大きめ"
+    assert _normalize_size_keyword(None) is None
+    assert _rounded_area_ratio(0.1234) == 0.123
+    assert _rounded_area_ratio(None) is None
+
+
+def test_extract_flags_discards_non_list_and_none_entries() -> None:
+    assert _extract_flags(["A", None, "B"]) == ["A", "B"]
+    assert _extract_flags("not-a-list") == []


### PR DESCRIPTION
## 概要
- `derive_usage_tags` と `generate_layout_description` の認知的複雑度を抑え、SonarCloud の CRITICAL 指摘 (#354, #358) を解消しました。
- 使用タグ推定やレイアウト説明生成の振る舞いは維持したまま、補助関数と状態オブジェクトへの分割で可読性と保守性を向上させています。

## 関連リンク
- Issue Close: Close #354, Close #358
- ToDo: なし
- ノート／設計資料: なし

## 変更内容
- `_UsageTagState` の導入などにより `derive_usage_tags` のロジックを再構成し、キーワード判定・派生タグ生成を分離。
- `generate_layout_description` を集計・説明生成用の補助関数に分割し、要素記述を一貫した形で組み立てるよう変更。
- 回帰テスト `tests/utils/test_layout_metadata.py` を追加し、使用タグ推定・レイアウト説明生成・要素数制限の振る舞いをカバー。

## ユーザー影響
- 生成されるレイアウトメタデータの内容に変更はなく、品質リスク（高複雑度によるメンテ負荷）の低減のみで直接的なユーザー影響はありません。
- 確認方法: 既存のレイアウト解析／テンプレート抽出フローを実行し、生成結果が従来と等価であることを比較します。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest --cov --cov-report xml`
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: なし
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている
- [x] Issue 自動クローズ用に `Close #<番号>` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した
- [ ] 影響範囲を確認し、必要なドキュメント・サンプルを更新した
- [ ] 生成物（PDF など）がある場合は添付または参照先を明記した
- [x] PR 本文中の `Close #<番号>` や `docs/todo/…` などのプレースホルダをすべて実際の値に置き換えた