### PR TITLE
fix: RM-084 prepare body lines complexity

### DIFF
--- a/src/pptx_generator/pipeline/prepare_normalization.py
+++ b/src/pptx_generator/pipeline/prepare_normalization.py
@@ -7,9 +7,15 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 import textwrap
-from typing import Any, Iterable
+from typing import Any
 
-from ..prepare import PrepareCard, PrepareDocument, PrepareGenerationMeta, PrepareLogEntry
+from ..prepare import (
+    PrepareBodyBlock,
+    PrepareCard,
+    PrepareDocument,
+    PrepareGenerationMeta,
+    PrepareLogEntry,
+)
 from ..models import (
     ContentApprovalDocument,
     ContentDocumentMeta,
@@ -262,70 +268,85 @@ class PrepareNormalizationStep:
         )
 
     def _build_body_lines(self, card: PrepareCard) -> list[str]:
-        def _split_text(value: str) -> list[str]:
-            stripped = value.strip()
-            if not stripped:
-                return []
-            segments = stripped.splitlines() if "\n" in stripped else [stripped]
-            output: list[str] = []
-            for segment in segments:
-                segment = segment.strip()
-                if not segment:
-                    continue
-                if len(segment) <= 200:
-                    output.append(segment)
-                else:
-                    wrapped = textwrap.wrap(
-                        segment,
-                        width=200,
-                        drop_whitespace=True,
-                        break_long_words=True,
-                    )
-                    output.extend(chunk.strip() for chunk in wrapped if chunk.strip())
-            return output
-
         lines: list[str] = []
         for block in card.content.body:
-            if block.type == "table":
-                continue
-            if block.type == "bullets" and block.data:
-                items = block.data.get("items")
-                if not isinstance(items, list):
-                    continue
-                for entry in items:
-                    if isinstance(entry, dict):
-                        text = str(entry.get("text") or "").strip()
-                        if not text:
-                            continue
-                        level_raw = entry.get("level", 0)
-                        try:
-                            level = max(int(level_raw), 0)
-                        except (TypeError, ValueError):
-                            level = 0
-                        prefix = "  " * level
-                        for segment in _split_text(text):
-                            lines.append(f"{prefix}{segment}")
-                    elif isinstance(entry, str):
-                        for segment in _split_text(entry):
-                            lines.append(segment)
-                continue
-
-            if isinstance(block.text, str):
-                for segment in _split_text(block.text):
-                    lines.append(segment)
-
-            if isinstance(block.description, str):
-                for segment in _split_text(block.description):
-                    lines.append(segment)
+            lines.extend(self._collect_block_lines(block))
 
         if lines:
             return lines
 
         headline = card.headline_or_title().strip()
-        if headline:
-            return [headline]
+        return [headline] if headline else []
+
+    def _collect_block_lines(self, block: PrepareBodyBlock) -> list[str]:
+        if block.type == "table":
+            return []
+
+        if block.type == "bullets":
+            return self._lines_from_bullets(block.data)
+
+        lines: list[str] = []
+        lines.extend(self._split_text(block.text))
+        lines.extend(self._split_text(block.description))
+        return lines
+
+    def _lines_from_bullets(self, raw_items: Any) -> list[str]:
+        items = raw_items.get("items") if isinstance(raw_items, dict) else None
+        if not isinstance(items, list):
+            return []
+
+        lines: list[str] = []
+        for entry in items:
+            lines.extend(self._lines_from_bullet_entry(entry))
+        return lines
+
+    def _lines_from_bullet_entry(self, entry: Any) -> list[str]:
+        if isinstance(entry, dict):
+            text = str(entry.get("text") or "").strip()
+            if not text:
+                return []
+            level = self._extract_bullet_level(entry.get("level", 0))
+            prefix = "  " * level
+            return [f"{prefix}{segment}" for segment in self._split_text(text)]
+
+        if isinstance(entry, str):
+            return self._split_text(entry)
 
         return []
+
+    @staticmethod
+    def _extract_bullet_level(value: Any) -> int:
+        try:
+            return max(int(value), 0)
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _split_text(value: Any) -> list[str]:
+        if not isinstance(value, str):
+            return []
+
+        stripped = value.strip()
+        if not stripped:
+            return []
+
+        segments = stripped.splitlines() if "\n" in stripped else [stripped]
+        output: list[str] = []
+        for segment in segments:
+            segment = segment.strip()
+            if not segment:
+                continue
+            if len(segment) <= 200:
+                output.append(segment)
+                continue
+            wrapped = textwrap.wrap(
+                segment,
+                width=200,
+                drop_whitespace=True,
+                break_long_words=True,
+            )
+            output.extend(chunk.strip() for chunk in wrapped if chunk.strip())
+        return output
 
     @staticmethod
     def _extract_table_data(card: PrepareCard) -> ContentTableData | None:

--- a/tests/pipeline/compose/test_draft_structuring_step.py
+++ b/tests/pipeline/compose/test_draft_structuring_step.py
@@ -364,6 +364,57 @@ def test_prepare_normalization_preserves_table_blocks() -> None:
     assert all("Outline | Owner" not in line for line in slide.elements.body)
 
 
+def test_build_body_lines_normalizes_text_and_bullets() -> None:
+    long_text = "x" * 210
+    card = PrepareCard(
+        card_id="body-lines-card",
+        role=PrepareCardRole(story_phase="problem", intent_tags=["detail"]),
+        content=PrepareCardContent(
+            headline="Main Headline",
+            body=[
+                PrepareBodyBlock(type="paragraph", text="  概要を整理します。  "),
+                PrepareBodyBlock(
+                    type="bullets",
+                    data={
+                        "items": [
+                            {"text": "ファクトを列挙", "level": 0},
+                            {"text": "補足情報を追加", "level": 2},
+                            "自由記述の項目",
+                            {"text": "", "level": 1},
+                            42,
+                        ]
+                    },
+                ),
+                PrepareBodyBlock(type="paragraph", description=long_text),
+            ],
+        ),
+        meta={},
+    )
+
+    step = PrepareNormalizationStep()
+    lines = step._build_body_lines(card)
+
+    assert lines[0] == "概要を整理します。"
+    assert lines[1] == "ファクトを列挙"
+    assert lines[2] == "    補足情報を追加"
+    assert "自由記述の項目" in lines
+    assert all(line for line in lines)
+    assert len(lines[-2]) <= 200
+    assert len(lines[-1]) <= 200
+
+
+def test_build_body_lines_falls_back_to_headline() -> None:
+    card = PrepareCard(
+        card_id="fallback-card",
+        role=PrepareCardRole(story_phase="impact", intent_tags=["summary"]),
+        content=PrepareCardContent(headline="重要なメッセージ", body=[]),
+        meta={},
+    )
+
+    step = PrepareNormalizationStep()
+    assert step._build_body_lines(card) == ["重要なメッセージ"]
+
+
 def test_merge_slide_elements_assigns_table_anchor() -> None:
     step = DraftStructuringStep()
     layout_profile = LayoutProfile(


### PR DESCRIPTION
## 概要
- `PrepareNormalizationStep._build_body_lines` の責務を補助メソッドへ分割し、SonarCloud の認知的複雑度指摘を解消できるようにしました。
- 差分カバレッジを担保するテストを追加し、長文分割や箇条書き整形の挙動を検証しました。

Close #355

## 関連リンク
- Issue Close: #355
- ToDo: なし
- ノート／設計資料: docs/notes/rm084-refactorability-assessment.md

## 変更内容
- `_build_body_lines` を `_collect_block_lines` ほかの補助メソッドへ分割し、段落・箇条書き整形とフォールバックを明示しました。
- 箇条書きのレベル抽出とテキスト分割ロジックをユーティリティ化し、再利用しやすい構造に整理しました。
- `tests/pipeline/compose/test_draft_structuring_step.py` に本文整形とヘッドラインフォールバックを確認するテストを追加しました。

## ユーザー影響
- CLI／パイプラインの表現は従来どおりで、内部実装の保守性が向上します。
- 異常な箇条書きデータを入力した場合でも、過剰なインデントや空行を抑制し安定した本文を生成できます。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest`
- [x] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: `uv tool run diff-cover coverage.xml --compare-branch origin/main`（差分カバレッジ 91%）
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した（対象 ToDo なし）
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている（更新不要）
- [x] Issue 自動クローズ用に `Close #355` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した（未対応）
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した
- [ ] 生成物（PDF など）がある場合は添付または参照先を明記した（対象なし）
- [x] PR 本文中の `Close #<番号>` や `docs/todo/…` などのプレースホルダをすべて実際の値に置き換えた