### PR TITLE
fix: RM-356 slide aligner complexity

### DIFF
--- a/src/pptx_generator/pipeline/slide_alignment.py
+++ b/src/pptx_generator/pipeline/slide_alignment.py
@@ -65,92 +65,154 @@ class SlideIdAligner:
     ) -> SlideAlignmentResult:
         if prepare_document is None or not prepare_document.cards:
             logger.info("SlideIdAligner: prepare_document が無いため整合処理をスキップします")
-            return SlideAlignmentResult(
-                document=content_document,
-                records=[],
-                meta={
-                    "status": "skipped",
-                    "reason": "prepare_document_absent",
-                },
-            )
+            return self._build_skip_result(content_document, "prepare_document_absent")
 
         card_map = {card.card_id: card for card in prepare_document.cards}
         candidate_slides = list(spec.slides)
         if not candidate_slides:
             logger.warning("SlideIdAligner: JobSpec にスライドが存在しません")
-            return SlideAlignmentResult(
-                document=content_document,
-                records=[],
-                meta={
-                    "status": "skipped",
-                    "reason": "jobspec_empty",
-                },
-            )
+            return self._build_skip_result(content_document, "jobspec_empty")
 
+        relevant_spec_ids = {
+            candidate.id for candidate in candidate_slides if candidate.id in card_map
+        }
         slide_assignments: dict[str, int] = {}
         records: list[SlideAlignmentRecord] = []
 
         for slide in content_document.slides:
-            original_id = slide.id
-            card = card_map.get(original_id)
-            if card is None:
-                logger.debug("SlideIdAligner: card_id=%s が prepare_document に見つかりません", original_id)
-                records.append(
-                    SlideAlignmentRecord(
-                        card_id=original_id,
-                        recommended_slide_id=None,
-                        confidence=0.0,
-                        reason="card_not_found",
-                        status="pending",
-                    )
-                )
-                continue
-
-            candidates = self._select_candidates(card, candidate_slides)
-            match_request = self._build_match_request(card, candidates)
-            response = self._client.match_slide(match_request)
-
-            candidate_ids = tuple(candidate.id for candidate in candidates)
-            record = SlideAlignmentRecord(
-                card_id=card.card_id,
-                recommended_slide_id=response.slide_id,
-                confidence=response.confidence,
-                reason=response.reason,
-                status="pending",
-                candidates=candidate_ids,
+            record = self._process_content_slide(
+                slide=slide,
+                card_map=card_map,
+                candidate_slides=candidate_slides,
+                slide_assignments=slide_assignments,
+                records=records,
             )
-
-            recommended_slide_id = response.slide_id
-            if recommended_slide_id and recommended_slide_id not in record.candidates:
-                recommended_slide_id = None
-                record.recommended_slide_id = None
-
-            if recommended_slide_id:
-                previous_index = slide_assignments.get(recommended_slide_id)
-                if previous_index is None:
-                    record.status = "applied"
-                    if response.confidence < self._options.confidence_threshold:
-                        record.reason = (record.reason or "") + " | low_confidence"
-                    slide_assignments[recommended_slide_id] = len(records)
-                else:
-                    previous_record = records[previous_index]
-                    if response.confidence > previous_record.confidence:
-                        previous_record.recommended_slide_id = None
-                        previous_record.status = "pending"
-                        previous_record.reason = (previous_record.reason or "") + " | reassigned"
-                        record.status = "applied"
-                        if response.confidence < self._options.confidence_threshold:
-                            record.reason = (record.reason or "") + " | low_confidence"
-                        slide_assignments[recommended_slide_id] = len(records)
-                    else:
-                        if previous_record.confidence < self._options.confidence_threshold:
-                            previous_record.reason = (previous_record.reason or "") + " | low_confidence"
-                        record.status = "pending"
-                        record.reason = (record.reason or "") + " | lower_than_existing"
-                        record.recommended_slide_id = None
             records.append(record)
 
-        assigned_slides = {slide_id for slide_id in slide_assignments}
+        fallback_applied = self._apply_fallback_assignments(records, slide_assignments)
+        updated_slides, applied = self._build_aligned_slides(content_document, records)
+        unmatched_spec_slides = self._collect_unmatched_spec_slides(
+            relevant_spec_ids, slide_assignments
+        )
+        records.extend(self._build_unmatched_records(unmatched_spec_slides))
+
+        aligned_document = content_document.model_copy(update={"slides": updated_slides})
+        meta = self._build_alignment_meta(
+            content_document=content_document,
+            relevant_spec_ids=relevant_spec_ids,
+            unmatched_spec_slides=unmatched_spec_slides,
+            applied=applied,
+            fallback=fallback_applied,
+            pending=sum(1 for record in records if record.status == "pending"),
+        )
+        logger.info(
+            "SlideIdAligner: cards_total=%d jobspec_total=%d jobspec_unassigned=%d applied=%d pending=%d threshold=%.2f",
+            meta["cards_total"],
+            meta["jobspec_total"],
+            meta["jobspec_unassigned"],
+            meta["applied"],
+            meta["pending"],
+            meta["threshold"],
+        )
+        return SlideAlignmentResult(document=aligned_document, records=records, meta=meta)
+
+    @staticmethod
+    def _build_skip_result(
+        content_document: ContentApprovalDocument,
+        reason: str,
+    ) -> SlideAlignmentResult:
+        return SlideAlignmentResult(
+            document=content_document,
+            records=[],
+            meta={
+                "status": "skipped",
+                "reason": reason,
+            },
+        )
+
+    def _process_content_slide(
+        self,
+        *,
+        slide: ContentSlide,
+        card_map: dict[str, PrepareCard],
+        candidate_slides: list[Slide],
+        slide_assignments: dict[str, int],
+        records: list[SlideAlignmentRecord],
+    ) -> SlideAlignmentRecord:
+        original_id = slide.id
+        card = card_map.get(original_id)
+        if card is None:
+            logger.debug("SlideIdAligner: card_id=%s が prepare_document に見つかりません", original_id)
+            return SlideAlignmentRecord(
+                card_id=original_id,
+                recommended_slide_id=None,
+                confidence=0.0,
+                reason="card_not_found",
+                status="pending",
+            )
+
+        candidates = self._select_candidates(card, candidate_slides)
+        match_request = self._build_match_request(card, candidates)
+        response = self._client.match_slide(match_request)
+
+        record = SlideAlignmentRecord(
+            card_id=card.card_id,
+            recommended_slide_id=response.slide_id,
+            confidence=response.confidence,
+            reason=response.reason,
+            status="pending",
+            candidates=tuple(candidate.id for candidate in candidates),
+        )
+        self._normalize_recommendation(record)
+        self._handle_assignment(record, slide_assignments, records)
+        return record
+
+    @staticmethod
+    def _normalize_recommendation(record: SlideAlignmentRecord) -> None:
+        if record.recommended_slide_id and record.recommended_slide_id not in record.candidates:
+            record.recommended_slide_id = None
+
+    def _handle_assignment(
+        self,
+        record: SlideAlignmentRecord,
+        slide_assignments: dict[str, int],
+        records: list[SlideAlignmentRecord],
+    ) -> None:
+        recommended_slide_id = record.recommended_slide_id
+        if not recommended_slide_id:
+            return
+
+        previous_index = slide_assignments.get(recommended_slide_id)
+        if previous_index is None:
+            record.status = "applied"
+            if record.confidence < self._options.confidence_threshold:
+                record.reason = self._append_reason(record.reason, "low_confidence")
+            slide_assignments[recommended_slide_id] = len(records)
+            return
+
+        previous_record = records[previous_index]
+        if record.confidence > previous_record.confidence:
+            previous_record.recommended_slide_id = None
+            previous_record.status = "pending"
+            previous_record.reason = self._append_reason(previous_record.reason, "reassigned")
+            record.status = "applied"
+            if record.confidence < self._options.confidence_threshold:
+                record.reason = self._append_reason(record.reason, "low_confidence")
+            slide_assignments[recommended_slide_id] = len(records)
+            return
+
+        if previous_record.confidence < self._options.confidence_threshold:
+            previous_record.reason = self._append_reason(previous_record.reason, "low_confidence")
+        record.status = "pending"
+        record.reason = self._append_reason(record.reason, "lower_than_existing")
+        record.recommended_slide_id = None
+
+    def _apply_fallback_assignments(
+        self,
+        records: list[SlideAlignmentRecord],
+        slide_assignments: dict[str, int],
+    ) -> int:
+        assigned_slides = set(slide_assignments)
         fallback_applied = 0
         for index, record in enumerate(records):
             if record.status == "applied" and record.recommended_slide_id:
@@ -163,59 +225,77 @@ class SlideIdAligner:
                 if candidate_id not in assigned_slides:
                     record.recommended_slide_id = candidate_id
                     record.status = "fallback"
-                    record.reason = (record.reason or "") + " | fallback_candidate"
+                    record.reason = self._append_reason(record.reason, "fallback_candidate")
                     assigned_slides.add(candidate_id)
                     slide_assignments[candidate_id] = index
                     fallback_applied += 1
                     break
+        return fallback_applied
+
+    def _build_aligned_slides(
+        self,
+        content_document: ContentApprovalDocument,
+        records: list[SlideAlignmentRecord],
+    ) -> tuple[list[ContentSlide], int]:
+        record_map: dict[str, SlideAlignmentRecord] = {}
+        for record in records:
+            record_map.setdefault(record.card_id, record)
 
         updated_slides: list[ContentSlide] = []
         applied = 0
         for slide in content_document.slides:
-            original_id = slide.id
-            record = next((entry for entry in records if entry.card_id == original_id), None)
+            record = record_map.get(slide.id)
             if record and record.recommended_slide_id and record.status in {"applied", "fallback"}:
                 updated_slides.append(slide.model_copy(update={"id": record.recommended_slide_id}))
                 applied += 1
             else:
                 updated_slides.append(slide)
+        return updated_slides, applied
 
-        relevant_spec_ids = {
-            candidate.id for candidate in candidate_slides if candidate.id in card_map
-        }
-        unmatched_spec_slides = [slide_id for slide_id in relevant_spec_ids if slide_id not in assigned_slides]
-        for slide_id in unmatched_spec_slides:
-            records.append(
-                SlideAlignmentRecord(
-                    card_id=slide_id,
-                    recommended_slide_id=None,
-                    confidence=0.0,
-                    reason="jobspec_unassigned",
-                    status="skipped",
-                )
+    @staticmethod
+    def _collect_unmatched_spec_slides(
+        relevant_spec_ids: set[str],
+        slide_assignments: dict[str, int],
+    ) -> list[str]:
+        return [slide_id for slide_id in relevant_spec_ids if slide_id not in slide_assignments]
+
+    @staticmethod
+    def _build_unmatched_records(slide_ids: Iterable[str]) -> list[SlideAlignmentRecord]:
+        return [
+            SlideAlignmentRecord(
+                card_id=slide_id,
+                recommended_slide_id=None,
+                confidence=0.0,
+                reason="jobspec_unassigned",
+                status="skipped",
             )
+            for slide_id in slide_ids
+        ]
 
-        aligned_document = content_document.model_copy(update={"slides": updated_slides})
-        meta = {
+    def _build_alignment_meta(
+        self,
+        *,
+        content_document: ContentApprovalDocument,
+        relevant_spec_ids: set[str],
+        unmatched_spec_slides: list[str],
+        applied: int,
+        fallback: int,
+        pending: int,
+    ) -> dict[str, object]:
+        return {
             "status": "completed",
             "threshold": self._options.confidence_threshold,
             "cards_total": len(content_document.slides),
             "jobspec_total": len(relevant_spec_ids),
             "jobspec_unassigned": len(unmatched_spec_slides),
             "applied": applied,
-            "fallback": fallback_applied,
-            "pending": sum(1 for record in records if record.status == "pending"),
+            "fallback": fallback,
+            "pending": pending,
         }
-        logger.info(
-            "SlideIdAligner: cards_total=%d jobspec_total=%d jobspec_unassigned=%d applied=%d pending=%d threshold=%.2f",
-            meta["cards_total"],
-            meta["jobspec_total"],
-            meta["jobspec_unassigned"],
-            meta["applied"],
-            meta["pending"],
-            meta["threshold"],
-        )
-        return SlideAlignmentResult(document=aligned_document, records=records, meta=meta)
+
+    @staticmethod
+    def _append_reason(origin: str | None, note: str) -> str:
+        return note if not origin else f"{origin} | {note}"
 
     def _build_match_request(
         self,

--- a/tests/layout_validation/test_slide_alignment_metrics.py
+++ b/tests/layout_validation/test_slide_alignment_metrics.py
@@ -153,3 +153,94 @@ def test_slide_id_aligner_does_not_replace_id_when_pending(monkeypatch: pytest.M
     assert record.status == "applied"
     assert record.recommended_slide_id == captured["candidate"]
     assert "low_confidence" in (record.reason or "")
+
+
+def test_slide_id_aligner_reassigns_to_higher_confidence(monkeypatch: pytest.MonkeyPatch) -> None:
+    spec = _build_spec()
+    prepare_doc = _build_prepare_document()
+    document = ContentApprovalDocument(
+        slides=[
+            ContentSlide(id="intro", intent="introduction", elements=ContentElements(title="イントロ")),
+            ContentSlide(id="solution", intent="solution", elements=ContentElements(title="解決策")),
+        ]
+    )
+    aligner = SlideIdAligner(SlideIdAlignerOptions(confidence_threshold=0.5))
+
+    responses = {
+        "intro": SlideMatchResponse(slide_id="solution-slide", confidence=0.4, reason="first"),
+        "solution": SlideMatchResponse(slide_id="solution-slide", confidence=0.9, reason="second"),
+    }
+
+    class StubClient:
+        def match_slide(self, request):
+            return responses[request.card_id]
+
+    monkeypatch.setattr(aligner, "_client", StubClient())
+
+    result = aligner.align(spec=spec, prepare_document=prepare_doc, content_document=document)
+
+    records = {record.card_id: record for record in result.records if record.card_id in {"intro", "solution"}}
+    assert records["solution"].status == "applied"
+    assert records["solution"].recommended_slide_id == "solution-slide"
+    assert records["intro"].status == "fallback"
+    reason = records["intro"].reason or ""
+    assert "reassigned" in reason
+    assert "fallback_candidate" in reason
+    assert result.meta["fallback"] == 1
+
+
+def test_slide_id_aligner_rejects_lower_confidence_recommendation(monkeypatch: pytest.MonkeyPatch) -> None:
+    spec = _build_spec()
+    prepare_doc = _build_prepare_document()
+    document = ContentApprovalDocument(
+        slides=[
+            ContentSlide(id="intro", intent="introduction", elements=ContentElements(title="イントロ")),
+            ContentSlide(id="solution", intent="solution", elements=ContentElements(title="解決策")),
+        ]
+    )
+    aligner = SlideIdAligner(SlideIdAlignerOptions(confidence_threshold=0.5))
+
+    responses = {
+        "intro": SlideMatchResponse(slide_id="intro-slide", confidence=0.2, reason="first"),
+        "solution": SlideMatchResponse(slide_id="intro-slide", confidence=0.1, reason="second"),
+    }
+
+    class StubClient:
+        def match_slide(self, request):
+            return responses[request.card_id]
+
+    monkeypatch.setattr(aligner, "_client", StubClient())
+
+    result = aligner.align(spec=spec, prepare_document=prepare_doc, content_document=document)
+
+    records = {record.card_id: record for record in result.records if record.card_id in {"intro", "solution"}}
+    assert records["intro"].status == "applied"
+    assert records["intro"].recommended_slide_id == "intro-slide"
+    assert "low_confidence" in (records["intro"].reason or "")
+    assert records["solution"].status == "fallback"
+    assert records["solution"].recommended_slide_id == "solution-slide"
+    assert "lower_than_existing" in (records["solution"].reason or "")
+
+
+def test_slide_id_aligner_applies_fallback_when_response_not_in_candidates(monkeypatch: pytest.MonkeyPatch) -> None:
+    spec = _build_spec()
+    prepare_doc = _build_prepare_document()
+    document = ContentApprovalDocument(
+        slides=[
+            ContentSlide(id="intro", intent="introduction", elements=ContentElements(title="イントロ")),
+        ]
+    )
+    aligner = SlideIdAligner()
+
+    class StubClient:
+        def match_slide(self, request):
+            return SlideMatchResponse(slide_id="external", confidence=0.7, reason="out-of-range")
+
+    monkeypatch.setattr(aligner, "_client", StubClient())
+
+    result = aligner.align(spec=spec, prepare_document=prepare_doc, content_document=document)
+
+    record = next(entry for entry in result.records if entry.card_id == "intro")
+    assert record.status == "fallback"
+    assert record.recommended_slide_id == "intro-slide"
+    assert "fallback_candidate" in (record.reason or "")


### PR DESCRIPTION
## 概要
- SlideIdAligner.align の責務分割を進め、SonarCloud が指摘した Cognitive Complexity を下げました。
- LLM 推論結果の重複解消／フォールバック判断を専用メソッドに切り出し、可読性と拡張性を改善しました。

## 関連リンク
- Issue Close: Close #356
- ToDo: 該当なし
- ノート／設計資料: docs/notes/20250214-context-engineering-hand-off.md

## 変更内容
- align 本体を入力検証・候補選定・割当処理・フォールバック・メタ集計に分割し、ヘルパーメソッドで整理。
- 推論結果の整合性チェックや理由付けの処理を `_normalize_recommendation` / `_append_reason` へ集約。
- 重複候補とフォールバック挙動を検証するテストケースを追加し、低信頼度や候補外応答の扱いを明示的にカバー。

## ユーザー影響
- Slide ID 整合ロジックの保守性が向上し、今後の仕様追加や閾値調整の影響範囲を把握しやすくなります。
- 差分は内部処理のみで、CLI などユーザー操作の変化はありません。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest --cov=pptx_generator.pipeline.slide_alignment --cov-report=term-missing`
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: なし
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている
- [x] Issue 自動クローズ用に `Close #356` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した
- [ ] 生成物（PDF など）がある場合は添付または参照先を明記した
- [x] PR 本文中の `Close #356` や `docs/todo/…` などのプレースホルダをすべて実際の値に置き換えた