### PR TITLE
refactor: RM-013 draft structuring simplification

### DIFF
--- a/src/pptx_generator/pipeline/draft_structuring/step.py
+++ b/src/pptx_generator/pipeline/draft_structuring/step.py
@@ -1200,79 +1200,128 @@ class DraftStructuringStep:
         if not anchor:
             return
         anchor_lower = anchor.lower()
+        if DraftStructuringStep._assign_special_anchor(elements, anchor_lower, card):
+            return
+
+        content_type = (slot.content_type or "text").lower()
+        if content_type == "table":
+            DraftStructuringStep._assign_table_content(elements, anchor, card, lines)
+            return
+        if content_type == "text":
+            DraftStructuringStep._assign_text_content(elements, anchor, anchor_lower, card, lines)
+            return
+
+    @staticmethod
+    def _assign_special_anchor(
+        elements: dict[str, Any],
+        anchor_lower: str,
+        card: PrepareCard,
+    ) -> bool:
         if anchor_lower in {"title", "main message"}:
             headline = card.headline_or_title()
             if headline:
                 elements["title"] = headline
-            return
+            return True
         if "subtitle" in anchor_lower:
             subtitle = card.subtitle_or_chapter() or card.headline_or_title()
             if subtitle:
                 elements["subtitle"] = subtitle
+            return True
+        return False
+
+    @staticmethod
+    def _assign_table_content(
+        elements: dict[str, Any],
+        anchor: str,
+        card: PrepareCard,
+        lines: list[str],
+    ) -> None:
+        table_block = next(
+            (block for block in card.content.body if block.type == "table"), None
+        )
+        if table_block and table_block.rows:
+            elements[anchor] = {
+                "headers": list(table_block.headers or []),
+                "rows": [list(row) for row in table_block.rows],
+            }
             return
-        content_type = (slot.content_type or "text").lower()
-        if content_type == "table":
-            table_block = next(
-                (block for block in card.content.body if block.type == "table"), None
-            )
-            if table_block and table_block.rows:
-                elements[anchor] = {
-                    "headers": list(table_block.headers or []),
-                    "rows": [list(row) for row in table_block.rows],
-                }
-            elif lines:
-                elements[anchor] = {
-                    "headers": ["項目"],
-                    "rows": [[line] for line in lines],
-                }
+        if lines:
+            elements[anchor] = {
+                "headers": ["項目"],
+                "rows": [[line] for line in lines],
+            }
+
+    @staticmethod
+    def _assign_text_content(
+        elements: dict[str, Any],
+        anchor: str,
+        anchor_lower: str,
+        card: PrepareCard,
+        lines: list[str],
+    ) -> None:
+        bullet_entries, paragraph_entries = DraftStructuringStep._extract_text_blocks(card)
+        if bullet_entries:
+            elements[anchor] = bullet_entries
             return
-        if content_type == "text":
-            bullet_entries: list[dict[str, Any]] = []
-            paragraph_entries: list[str] = []
-            for block in card.content.body:
-                if block.type == "bullets" and block.data:
-                    raw_items = block.data.get("items")
-                    if isinstance(raw_items, list):
-                        for entry in raw_items:
-                            if isinstance(entry, dict):
-                                text = str(entry.get("text") or "").strip()
-                                if not text:
-                                    continue
-                                level_raw = entry.get("level", 0)
-                                try:
-                                    level = max(int(level_raw), 0)
-                                except (TypeError, ValueError):
-                                    level = 0
-                                bullet_entry: dict[str, Any] = {"text": text, "level": level}
-                                for key, value in entry.items():
-                                    if key in {"text", "level"}:
-                                        continue
-                                    bullet_entry[key] = value
-                                bullet_entries.append(bullet_entry)
-                            elif isinstance(entry, str):
-                                text = entry.strip()
-                                if text:
-                                    bullet_entries.append({"text": text, "level": 0})
-                elif isinstance(block.text, str) and block.text.strip():
-                    paragraph_entries.append(block.text.strip())
-            if bullet_entries:
-                elements[anchor] = bullet_entries
-                return
-            if paragraph_entries:
-                elements[anchor] = paragraph_entries
-                return
-            if lines:
-                elements[anchor] = lines
-                return
-            if anchor_lower in {"body", "content"}:
-                headline = card.headline_or_title()
-                if headline:
-                    elements[anchor] = [headline]
-            return
-        if content_type not in {"text"}:
+        if paragraph_entries:
+            elements[anchor] = paragraph_entries
             return
         if lines:
             elements[anchor] = lines
+            return
+        if anchor_lower in {"body", "content"}:
+            headline = card.headline_or_title()
+            if headline:
+                elements[anchor] = [headline]
+
+    @staticmethod
+    def _extract_text_blocks(card: PrepareCard) -> tuple[list[dict[str, Any]], list[str]]:
+        bullet_entries: list[dict[str, Any]] = []
+        paragraph_entries: list[str] = []
+        for block in card.content.body:
+            if block.type == "bullets" and block.data:
+                DraftStructuringStep._append_bullet_entries(block.data.get("items"), bullet_entries)
+                continue
+            if isinstance(block.text, str):
+                text = block.text.strip()
+                if text:
+                    paragraph_entries.append(text)
+        return bullet_entries, paragraph_entries
+
+    @staticmethod
+    def _append_bullet_entries(
+        raw_items: Any,
+        bullet_entries: list[dict[str, Any]],
+    ) -> None:
+        if not isinstance(raw_items, list):
+            return
+        for entry in raw_items:
+            if isinstance(entry, dict):
+                DraftStructuringStep._append_dict_bullet(entry, bullet_entries)
+            elif isinstance(entry, str):
+                text = entry.strip()
+                if text:
+                    bullet_entries.append({"text": text, "level": 0})
+
+    @staticmethod
+    def _append_dict_bullet(
+        entry: dict[str, Any],
+        bullet_entries: list[dict[str, Any]],
+    ) -> None:
+        text = str(entry.get("text") or "").strip()
+        if not text:
+            return
+        level_raw = entry.get("level", 0)
+        try:
+            level = max(int(level_raw), 0)
+        except (TypeError, ValueError):
+            level = 0
+        bullet_entry: dict[str, Any] = {"text": text, "level": level}
+        for key, value in entry.items():
+            if key in {"text", "level"}:
+                continue
+            bullet_entry[key] = value
+        bullet_entries.append(bullet_entry)
 
     @staticmethod
     def _merge_slide_notes(elements: dict[str, Any], note_lines: list[str]) -> None:

--- a/tests/pipeline/compose/test_draft_structuring_step.py
+++ b/tests/pipeline/compose/test_draft_structuring_step.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -23,6 +24,7 @@ from pptx_generator.models import (
     JobSpec,
     Slide,
     SlideTable,
+    TemplateBlueprintSlot,
 )
 from pptx_generator.draft_recommender import LayoutProfile
 from pptx_generator.prepare import (
@@ -362,6 +364,170 @@ def test_prepare_normalization_preserves_table_blocks() -> None:
     assert slide.elements.table_data is not None
     assert slide.elements.table_data.headers == ["Stage", "Owner", "Mode"]
     assert all("Outline | Owner" not in line for line in slide.elements.body)
+
+
+def test_assign_slot_handles_title_and_subtitle() -> None:
+    card = PrepareCard(
+        card_id="intro",
+        role=PrepareCardRole(story_phase="introduction", intent_tags=[]),
+        content=PrepareCardContent(
+            headline="Main Headline",
+            subtitle="Sub Headline",
+            body=[],
+        ),
+    )
+    elements: dict[str, Any] = {}
+
+    title_slot = TemplateBlueprintSlot(
+        slot_id="title-slot",
+        anchor="Title",
+        content_type="text",
+    )
+    DraftStructuringStep._assign_slot_to_elements(elements, title_slot, card, lines=[])
+    assert elements["title"] == "Main Headline"
+
+    subtitle_slot = TemplateBlueprintSlot(
+        slot_id="subtitle-slot",
+        anchor="Slide_Subtitle",
+        content_type="text",
+    )
+    DraftStructuringStep._assign_slot_to_elements(elements, subtitle_slot, card, lines=[])
+    assert elements["subtitle"] == "Sub Headline"
+
+
+def test_assign_slot_table_prefers_table_block() -> None:
+    card = PrepareCard(
+        card_id="table-card",
+        role=PrepareCardRole(story_phase="solution", intent_tags=[]),
+        content=PrepareCardContent(
+            headline="Table Slide",
+            body=[
+                PrepareBodyBlock(
+                    type="table",
+                    headers=["項目", "値"],
+                    rows=[["A", "1"]],
+                )
+            ],
+        ),
+    )
+    elements: dict[str, Any] = {}
+    slot = TemplateBlueprintSlot(
+        slot_id="slot",
+        anchor="DataTable",
+        content_type="table",
+    )
+
+    DraftStructuringStep._assign_slot_to_elements(elements, slot, card, lines=["fallback"])
+
+    assert elements["DataTable"]["headers"] == ["項目", "値"]
+    assert elements["DataTable"]["rows"] == [["A", "1"]]
+
+
+def test_assign_slot_table_falls_back_to_lines() -> None:
+    card = PrepareCard(
+        card_id="table-card",
+        role=PrepareCardRole(story_phase="solution", intent_tags=[]),
+        content=PrepareCardContent(headline="Table Slide", body=[]),
+    )
+    elements: dict[str, Any] = {}
+    slot = TemplateBlueprintSlot(
+        slot_id="slot",
+        anchor="DataTable",
+        content_type="table",
+    )
+
+    DraftStructuringStep._assign_slot_to_elements(elements, slot, card, lines=["項目A"])
+
+    assert elements["DataTable"]["rows"] == [["項目A"]]
+
+
+def test_assign_slot_text_prefers_bullets() -> None:
+    card = PrepareCard(
+        card_id="bullet-card",
+        role=PrepareCardRole(story_phase="solution", intent_tags=[]),
+        content=PrepareCardContent(
+            headline="Headline",
+            body=[
+                PrepareBodyBlock(
+                    type="bullets",
+                    data={
+                        "items": [
+                            {"text": "Line 1", "level": 0, "extra": "meta"},
+                            "Line 2",
+                        ]
+                    },
+                )
+            ],
+        ),
+    )
+    elements: dict[str, Any] = {}
+    slot = TemplateBlueprintSlot(
+        slot_id="slot",
+        anchor="Body",
+        content_type="text",
+    )
+
+    DraftStructuringStep._assign_slot_to_elements(elements, slot, card, lines=["fallback"])
+
+    assert elements["Body"][0] == {"text": "Line 1", "level": 0, "extra": "meta"}
+    assert elements["Body"][1] == {"text": "Line 2", "level": 0}
+
+
+def test_assign_slot_text_prefers_paragraphs_when_no_bullets() -> None:
+    card = PrepareCard(
+        card_id="paragraph-card",
+        role=PrepareCardRole(story_phase="solution", intent_tags=[]),
+        content=PrepareCardContent(
+            headline="Headline",
+            body=[PrepareBodyBlock(type="paragraph", text="Paragraph content")],
+        ),
+    )
+    elements: dict[str, Any] = {}
+    slot = TemplateBlueprintSlot(
+        slot_id="slot",
+        anchor="Body",
+        content_type="text",
+    )
+
+    DraftStructuringStep._assign_slot_to_elements(elements, slot, card, lines=["fallback"])
+
+    assert elements["Body"] == ["Paragraph content"]
+
+
+def test_assign_slot_text_uses_lines_when_no_content() -> None:
+    card = PrepareCard(
+        card_id="lines-card",
+        role=PrepareCardRole(story_phase="solution", intent_tags=[]),
+        content=PrepareCardContent(headline="Headline", body=[]),
+    )
+    elements: dict[str, Any] = {}
+    slot = TemplateBlueprintSlot(
+        slot_id="slot",
+        anchor="Body",
+        content_type="text",
+    )
+
+    DraftStructuringStep._assign_slot_to_elements(elements, slot, card, lines=["Fallback"])
+
+    assert elements["Body"] == ["Fallback"]
+
+
+def test_assign_slot_text_falls_back_to_headline_for_body_anchor() -> None:
+    card = PrepareCard(
+        card_id="headline-card",
+        role=PrepareCardRole(story_phase="solution", intent_tags=[]),
+        content=PrepareCardContent(headline="Headline Only", body=[]),
+    )
+    elements: dict[str, Any] = {}
+    slot = TemplateBlueprintSlot(
+        slot_id="slot",
+        anchor="Content",
+        content_type="text",
+    )
+
+    DraftStructuringStep._assign_slot_to_elements(elements, slot, card, lines=[])
+
+    assert elements["Content"] == ["Headline Only"]
 
 
 def test_build_body_lines_normalizes_text_and_bullets() -> None:


### PR DESCRIPTION
## 概要
- SonarCloud の CRITICAL 指摘 (python:S3776) を受けて、`_assign_slot_to_elements` の認知的複雑度を削減しました。
- スロット割当てを責務別ヘルパー (`_assign_special_anchor` / `_assign_table_content` / `_assign_text_content`) へ切り出し、分岐を整理しています。
- 新しい単体テストでタイトル／テーブル／テキストなどのケースをカバーし、挙動の退行を防ぎます。

## 関連リンク
- Issue Close: Close #370
- ToDo: (該当なし)
- ノート／設計資料: (該当なし)

## 変更内容
- `_assign_slot_to_elements` を責務単位に分割し、箇条書き抽出やテーブル処理をヘルパー化しました。
- `_extract_text_blocks` などの補助関数を追加し、テキスト系スロットの判定を明確化しました。
- 追加テストでタイトル／サブタイトル、テーブルフォールバック、段落／箇条書きなどの割当てロジックを検証します。

## ユーザー影響
- Analyzer など下流への出力仕様は不変で、ドラフト構成の結果は従来どおりです。
- リファクタリングにより今後の仕様追加時のリスクが低減します。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest --cov=src/pptx_generator --cov-report=xml`
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: なし
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている
- [x] Issue 自動クローズ用に `Close #370` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した
- [ ] 生成物（PDF など）がある場合は添付または参照先を明記した
- [x] PR 本文中の `Close #370` や `docs/todo/…` などのプレースホルダをすべて実際の値に置き換えた