### PR TITLE
fix: RM-000 ai summary return flag

### DIFF
--- a/src/pptx_generator/pipeline/draft_structuring/dynamic_flow.py
+++ b/src/pptx_generator/pipeline/draft_structuring/dynamic_flow.py
@@ -311,14 +311,15 @@ def _update_ai_summary(
     if ai_used:
         accumulator.ai_summary["used"] += 1
 
-    if recommendation.ai_response is not None:
+    ai_response = recommendation.ai_response
+    simulated = False
+
+    if ai_response is not None:
         accumulator.ai_summary["invoked"] += 1
-        model = recommendation.ai_response.model or "unknown"
+        model = ai_response.model or "unknown"
         models = accumulator.ai_summary["models"]
         models[model] = models.get(model, 0) + 1
-        return ai_used
-
-    if (
+    elif (
         options.enable_ai_recommender
         and options.enable_ai_simulation
         and options.ai_weight > 0
@@ -326,13 +327,14 @@ def _update_ai_summary(
         and _has_positive_ai_recommendation(recommendation.candidates)
     ):
         accumulator.ai_summary["simulated"] += 1
+        simulated = True
         if logger.isEnabledFor(logging.INFO):
             logger.info(
                 "layout AI simulated: slide_id=%s preferred=%s",
                 slide_id,
                 preferred_layout,
             )
-    return ai_used
+    return ai_used or simulated
 
 
 def _build_mapping_entry(

--- a/tests/pipeline/compose/test_dynamic_flow.py
+++ b/tests/pipeline/compose/test_dynamic_flow.py
@@ -175,6 +175,8 @@ def test_process_work_item_tracks_ai_simulation_when_no_scores() -> None:
     )
 
     assert accumulator.ai_summary["simulated"] == 1
+    assert accumulator.ai_summary["used"] == 0
+    assert accumulator.mapping_logs[0]["ai_recommendation_used"] is True
 
 
 def test_resolve_section_prefers_story_angle_over_chapter_id() -> None:


### PR DESCRIPTION
## 概要
- Issue #378 の BLOCKER 指摘に対応し、AI サマリ集計がシミュレーション時にも正しい真偽値を返すよう修正しました。
- `_update_ai_summary` の戻り値が常に `ai_used` だった問題を解消し、シミュレートされたケースでも呼び出し元が AI 活用を把握できるようにしました。

## 関連リンク
- Issue Close: #378
- ToDo: なし
- ノート／設計資料: なし

## 変更内容
- `_update_ai_summary` が AI 応答とシミュレーションの両方を考慮して戻り値を返すように調整。
- AI シミュレーション経路で `ai_recommendation_used` が True になることを検証するテストを追加。

## ユーザー影響
- ドラフト化された資料の AI 利用状況サマリが実態に一致するようになり、レポートの信頼性が向上します。
- 確認方法: `uv run --extra dev pytest` を実行し、AI サマリ関連テストの成功を確認します。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest`
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: なし
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている
- [x] Issue 自動クローズ用に `Close #378` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した
- [ ] 影響範囲を確認し、必要なドキュメント・サンプルを更新した
- [ ] 生成物（PDF など）がある場合は添付または参照先を明記した
- [x] PR 本文中の `Close #<番号>` や `docs/todo/…` などのプレースホルダをすべて実際の値に置き換えた
