### PR TITLE
docs: RM-000 ignore external gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,6 @@ node_modules/
 
 # Local external hooks (keep docs only)
 external/*
+external/.gitignore
 !external/README.md
 !external/AGENTS.md


### PR DESCRIPTION
## 概要
- `external/.gitignore` をリポジトリ追跡から除外し、外部テンプレート領域でローカル調整した `.gitignore` が誤ってコミットに含まれないよう整備しました。
- `external/AGENTS.md` で示されている「external/ は Git 管理外」という運用方針と実態を揃え、常時クリーンな作業ツリーを維持します。

## 関連リンク
- Issue Close: Close #410
- ToDo: なし（ユーザー指示により作成対象外）
- ノート／設計資料: なし

## 変更内容
- ルート `.gitignore` に `external/.gitignore` を追加し、Git が当該ファイルを無視するようにしました。
- コード・テスト・ドキュメント・サンプル類の追加変更はありません。

## ユーザー影響
- 外部テンプレート作業時に `external/.gitignore` が未追跡ファイルとして表示されなくなり、誤コミットのリスクを低減します。
- `git status` を実行し、`external/.gitignore` が表示されないことを確認することで影響を検証できます。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest --cov --cov-report=xml`
- [x] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: `uv tool run diff-cover coverage.xml --compare-branch origin/main`
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した（今回タスクは ToDo 作成不要の指示のため対象なし）
- [x] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている（本対応では変更なし）
- [x] Issue 自動クローズ用に `Close #410` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した（必要に応じて後続対応）
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した（不要であることを確認）
- [x] 生成物（PDF など）がある場合は添付または参照先を明記した（生成物なし）
- [x] PR 本文中の `Close #<番号>` や `docs/todo/…` などのプレースホルダをすべて実値に置き換えた