### PR TITLE
fix: RM-405 mime case-fold

### DIFF
--- a/src/pptx_generator/content_import/service.py
+++ b/src/pptx_generator/content_import/service.py
@@ -188,9 +188,10 @@ class ContentImportService:
 
         hash_value = sha256(raw).hexdigest()
         retrieved_at = datetime.now(timezone.utc)
+        normalized_content_type = (content_type or "").lower()
         warnings: list[str] = []
 
-        if content_type and "pdf" in content_type:
+        if "pdf" in normalized_content_type:
             with NamedTemporaryFile(suffix=".pdf", delete=False) as tmp_file:
                 tmp_file.write(raw)
                 tmp_path = Path(tmp_file.name)
@@ -215,9 +216,9 @@ class ContentImportService:
             text = raw.decode(encoding, errors="ignore")
             warnings.append("レスポンスのデコード時に無効なバイトを無視しました")
 
-        if content_type and "html" in content_type:
+        if "html" in normalized_content_type:
             text = self._html_to_text(text)
-        elif content_type and "json" in content_type:
+        elif "json" in normalized_content_type:
             text = self._json_to_text(text, warnings)
 
         return _SourcePayload(
@@ -244,6 +245,7 @@ class ContentImportService:
         mime_part, data_part = mime_and_data
         is_base64 = mime_part.endswith(";base64")
         mime_type = mime_part.split(";", maxsplit=1)[0] if ";" in mime_part else mime_part
+        normalized_mime_type = (mime_type or "").lower()
         raw: bytes
         if is_base64:
             raw = base64.b64decode(data_part)
@@ -254,7 +256,7 @@ class ContentImportService:
         retrieved_at = datetime.now(timezone.utc)
         warnings: list[str] = []
 
-        if "pdf" in mime_type:
+        if "pdf" in normalized_mime_type:
             with NamedTemporaryFile(suffix=".pdf", delete=False) as tmp_file:
                 tmp_file.write(raw)
                 tmp_path = Path(tmp_file.name)
@@ -269,9 +271,9 @@ class ContentImportService:
             except UnicodeDecodeError:
                 text = raw.decode(encoding, errors="ignore")
                 warnings.append("data URI のデコード時に無効なバイトを無視しました")
-            if "html" in mime_type:
+            if "html" in normalized_mime_type:
                 text = self._html_to_text(text)
-            elif "json" in mime_type:
+            elif "json" in normalized_mime_type:
                 text = self._json_to_text(text, warnings)
 
         return _SourcePayload(

--- a/tests/content_import/test_content_import_pipeline.py
+++ b/tests/content_import/test_content_import_pipeline.py
@@ -92,3 +92,113 @@ def test_convert_pdf_error_message_contains_stdout_and_stderr(
     message = str(exc_info.value)
     assert "draw import failure" in message
     assert "Error: Please verify input parameters..." in message
+
+
+def test_load_http_source_handles_uppercase_pdf(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = ContentImportService()
+
+    convert_called = False
+
+    def fake_convert_pdf(self: ContentImportService, path: Path) -> str:  # noqa: D401
+        nonlocal convert_called
+        convert_called = True
+        assert path.exists()
+        return "converted from pdf"
+
+    class FakeResponse:
+        headers = {"Content-Type": "APPLICATION/PDF"}
+
+        def read(self) -> bytes:  # noqa: D401
+            return b"%PDF-1.4 mock"
+
+        def __enter__(self) -> "FakeResponse":  # noqa: D401
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:  # noqa: D401, ANN001
+            return False
+
+    def fake_urlopen(request: object, timeout: int = 0) -> FakeResponse:  # noqa: D401, ANN001
+        return FakeResponse()
+
+    monkeypatch.setattr("pptx_generator.content_import.service.urlopen", fake_urlopen)
+    monkeypatch.setattr(ContentImportService, "_convert_pdf", fake_convert_pdf)
+
+    payload = service._load_http_source("https://example.com/file.pdf")
+
+    assert convert_called
+    assert payload.content_type == "application/pdf"
+    assert payload.text == "converted from pdf"
+
+
+def test_load_data_uri_handles_uppercase_html() -> None:
+    data_uri = "data:TEXT/HTML;charset=utf-8,%3Ch1%3ETitle%3C/h1%3E%0A%3Cp%3EBody%3C/p%3E"
+
+    service = ContentImportService()
+    payload = service._load_data_uri(data_uri)
+
+    assert "Title" in payload.text
+    assert "Body" in payload.text
+    assert "<" not in payload.text
+
+
+def test_load_http_source_handles_uppercase_html(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = ContentImportService()
+
+    class FakeResponse:
+        headers = {"Content-Type": "TEXT/HTML; charset=utf-8"}
+
+        def read(self) -> bytes:  # noqa: D401
+            return b"<h1>Heading</h1><p>body</p>"
+
+        def __enter__(self) -> "FakeResponse":  # noqa: D401
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:  # noqa: D401, ANN001
+            return False
+
+    def fake_urlopen(request: object, timeout: int = 0) -> FakeResponse:  # noqa: D401, ANN001
+        return FakeResponse()
+
+    monkeypatch.setattr("pptx_generator.content_import.service.urlopen", fake_urlopen)
+
+    payload = service._load_http_source("https://example.com/page.html")
+
+    assert "Heading" in payload.text
+    assert "body" in payload.text
+    assert "<" not in payload.text
+
+
+def test_load_http_source_handles_uppercase_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = ContentImportService()
+
+    class FakeResponse:
+        headers = {"Content-Type": "APPLICATION/JSON"}
+
+        def read(self) -> bytes:  # noqa: D401
+            return b'{"title": "Hello"}'
+
+        def __enter__(self) -> "FakeResponse":  # noqa: D401
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:  # noqa: D401, ANN001
+            return False
+
+    def fake_urlopen(request: object, timeout: int = 0) -> FakeResponse:  # noqa: D401, ANN001
+        return FakeResponse()
+
+    monkeypatch.setattr("pptx_generator.content_import.service.urlopen", fake_urlopen)
+
+    payload = service._load_http_source("https://example.com/data.json")
+
+    assert '"title": "Hello"' in payload.text
+    assert "<" not in payload.text
+
+
+def test_load_data_uri_handles_uppercase_json() -> None:
+    data_uri = "data:APPLICATION/JSON;charset=utf-8,%7B%22title%22%3A%22Hello%22%7D"
+
+    service = ContentImportService()
+    payload = service._load_data_uri(data_uri)
+
+    assert '"title": "Hello"' in payload.text
+    assert "<" not in payload.text


### PR DESCRIPTION
## 概要
- ContentImportService の HTTP/HTTPS・data URI における MIME 判定を大小文字非依存に修正し、大文字 MIME タイプのケースで PDF/HTML/JSON が正しく処理されるようにしました。
- 大文字 MIME 入力の回帰を防ぐユニットテストを追加しました。

## 関連リンク
- Issue Close: Close #405
- ToDo: 該当なし（今回のタスクでは ToDo/RM 作成不要の指示）
- ノート／設計資料: なし

## 変更内容
- MIME 判定用に `content_type` / `mime_type` を小文字化して分岐に適用。
- 大文字 MIME (PDF/HTML/JSON) の HTTP/data URI 入力をカバーするユニットテストを追加。

## ユーザー影響
- 大文字表記の Content-Type でも PDF 変換や HTML/JSON 正規化が正しく行われ、インポートエラーを防止できます。
- 確認方法: `uv run pptx prepare https://example.com/file.pdf --mode dynamic` のような大文字 MIME 応答でエラーなく PDF として処理されること、data URI でも HTML/JSON がプレーンテキスト化されることを確認。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest` / `uv tool run diff-cover coverage.xml --compare-branch origin/main`
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: なし
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている
- [x] Issue 自動クローズ用に `Close #<番号>` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した
- [ ] 生成物（PDF など）がある場合は添付または参照先を明記した
- [x] PR 本文中の `Close #<番号>` や `docs/todo/…` などのプレースホルダをすべて実際の値に置き換えた