### PR TITLE
fix: RM-402 local import normalization

### DIFF
--- a/src/pptx_generator/content_import/service.py
+++ b/src/pptx_generator/content_import/service.py
@@ -163,7 +163,15 @@ class ContentImportService:
             except UnicodeDecodeError:
                 text = raw.decode("utf-8", errors="ignore")
                 warnings.append("UTF-8 で解釈できない文字を無視しました")
-            content_type = "text/plain"
+
+            if suffix in {".html", ".htm"}:
+                text = self._html_to_text(text)
+                content_type = "text/html"
+            elif suffix == ".json":
+                text = self._json_to_text(text, warnings)
+                content_type = "application/json"
+            else:
+                content_type = "text/plain"
 
         return _SourcePayload(
             source=str(path),

--- a/tests/content_import/test_content_import_pipeline.py
+++ b/tests/content_import/test_content_import_pipeline.py
@@ -40,6 +40,34 @@ def test_import_without_sources_raises() -> None:
         service.import_sources([])
 
 
+def test_import_from_local_html(tmp_path: Path) -> None:
+    source = tmp_path / "page.html"
+    source.write_text("<h1>Summary</h1><p>売上が前年比+20%です</p>", encoding="utf-8")
+
+    service = ContentImportService()
+    result = service.import_sources([str(source)])
+
+    slide = result.document.slides[0]
+    body_joined = "\n".join(slide.elements.body)
+    assert "Summary" in slide.elements.title or "Summary" in body_joined
+    assert "<" not in body_joined
+    assert result.meta["total_slides"] == len(result.document.slides)
+
+
+def test_import_from_local_json(tmp_path: Path) -> None:
+    source = tmp_path / "payload.json"
+    source.write_text('{"title": "Hello", "body": "World"}', encoding="utf-8")
+
+    service = ContentImportService()
+    result = service.import_sources([str(source)])
+
+    slide = result.document.slides[0]
+    text_joined = "\n".join(slide.elements.body)
+    assert '"title": "Hello"' in text_joined
+    assert "<" not in text_joined
+    assert result.meta["total_slides"] == len(result.document.slides)
+
+
 def test_convert_pdf_retries_with_writer_infilter(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     pdf_path = tmp_path / "sample.pdf"
     pdf_path.write_bytes(b"%PDF-1.4 mock")


### PR DESCRIPTION
## 概要
- ローカル入力の HTML/JSON でも HTTP と同様に正規化を適用し、マークアップが出力に残らないようにしました。
- 大文字 MIME の回帰テストに加え、ローカル HTML/JSON のユニットテストを追加しました。

## 関連リンク
- Issue Close: Close #402
- ToDo: 該当なし（今回のタスクでは ToDo/RM 作成不要の指示）
- ノート／設計資料: なし

## 変更内容
- `_load_file_source` で拡張子 `.html`/`.htm`/`.json` を判定し、`_html_to_text` / `_json_to_text` を適用するよう変更。
- ローカル HTML/JSON の取り込みテストを追加し、プレーンテキスト化とメタ計算を確認。

## ユーザー影響
- ローカル HTML/JSON を `uv run pptx prepare <file> --mode dynamic` で読み込んでもタグが混入せず、HTTP 由来と同等の正規化結果になります。
- 手順: サンプル HTML/JSON をローカルに置き、上記コマンドで生成された `prepare_card.json` などにマークアップが残らないことを確認。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest` / `uv tool run diff-cover coverage.xml --compare-branch origin/main`
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: なし
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている
- [x] Issue 自動クローズ用に `Close #<番号>` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した
- [ ] 生成物（PDF など）がある場合は添付または参照先を明記した
- [x] PR 本文中の `Close #<番号>` や `docs/todo/…` などのプレースホルダをすべて実際の値に置き換えた