### PR TITLE
fix: RM-000 mapping-candidate-score

### DIFF
--- a/src/pptx_generator/pipeline/mapping/processor.py
+++ b/src/pptx_generator/pipeline/mapping/processor.py
@@ -206,7 +206,11 @@ class MappingSlideProcessor:
     ) -> list[MappingCandidate]:
         merged = {candidate.layout_id: candidate.score for candidate in scorer_candidates}
         for candidate in card_candidates:
-            merged.setdefault(candidate.layout_id, candidate.score)
+            existing_score = merged.get(candidate.layout_id)
+            if existing_score is None:
+                merged[candidate.layout_id] = candidate.score
+                continue
+            merged[candidate.layout_id] = max(existing_score, candidate.score)
         result = [
             MappingCandidate(layout_id=layout_id, score=score)
             for layout_id, score in merged.items()

--- a/tests/pipeline/mapping/test_mapping_step_layout_assignment.py
+++ b/tests/pipeline/mapping/test_mapping_step_layout_assignment.py
@@ -9,15 +9,27 @@ from typing import Iterable
 
 import pytest
 
-from pptx_generator.models import (ContentApprovalDocument, ContentDocumentMeta,
-                                   ContentElements, ContentSlide,
-                                   ContentTableData, DraftDocument,
-                                   DraftSection, DraftSlideCard,
-                                   GenerateReadyDocument, JobAuth, JobMeta,
-                                   JobSpec, PipelineFallbackError, Slide,
-                                   SlideTable)
+from pptx_generator.models import (
+    ContentApprovalDocument,
+    ContentDocumentMeta,
+    ContentElements,
+    ContentSlide,
+    ContentTableData,
+    DraftDocument,
+    DraftSection,
+    DraftSlideCard,
+    GenerateReadyDocument,
+    JobAuth,
+    JobMeta,
+    JobSpec,
+    MappingCandidate,
+    PipelineFallbackError,
+    Slide,
+    SlideTable,
+)
 from pptx_generator.pipeline.base import PipelineContext
 from pptx_generator.pipeline.mapping import MappingOptions, MappingStep
+from pptx_generator.pipeline.mapping.processor import MappingSlideProcessor
 from pptx_generator.prepare import (
     PrepareBodyBlock,
     PrepareCard,
@@ -65,6 +77,25 @@ def _attach_minimal_draft_document(context: PipelineContext, spec: JobSpec) -> N
     draft_section = DraftSection(name="auto", order=1, slides=draft_cards)
     draft_document = DraftDocument(sections=[draft_section])
     context.add_artifact("draft_document", draft_document)
+
+
+def test_merge_layout_candidates_prefers_card_score(tmp_path: Path) -> None:
+    processor = MappingSlideProcessor(
+        options=MappingOptions(output_dir=tmp_path),
+        layout_catalog={},
+    )
+    scorer_candidates = [
+        MappingCandidate(layout_id="title", score=0.5),
+        MappingCandidate(layout_id="two_column", score=0.3),
+    ]
+    card_candidates = [MappingCandidate(layout_id="two_column", score=0.95)]
+
+    merged = processor._merge_layout_candidates(scorer_candidates, card_candidates)
+
+    assert merged[0].layout_id == "two_column"
+    assert merged[0].score == 0.95, "カード側のスコアがヒューリスティックより低くならないこと"
+    assert merged[1].layout_id == "title"
+    assert merged[1].score == 0.5
 
 
 def test_mapping_step_generates_generate_ready_outputs(tmp_path: Path) -> None:


### PR DESCRIPTION
## 概要
- MappingStep でカード側の layout_candidates スコアがヒューリスティックに負けて無視されるバグを修正。
- HITL/Compose で指定した優先レイアウトが確実に反映されるよう、重複 layout_id のマージ時にカード側スコアを最大値として採用。
- 上記挙動をカバーするユニットテストを追加。

## 関連リンク
- Issue Close: Close #403
- ToDo: なし（今回のタスクでは ToDo 未作成）
- ノート／設計資料: なし

## 変更内容
- `_merge_layout_candidates` のマージロジックを見直し、カード側スコアを優先（最大値）で統合。
- カード側とヒューリスティック側で同一 layout_id を持つケースのユニットテストを追加。

## ユーザー影響
- HITL/Compose で指定したレイアウト優先度がマッピング結果に反映されるようになる。
- 確認方法: `MappingSlideProcessor` の候補統合部を通るパイプライン実行、または追加テストの成功を確認。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest`
  - 差分カバレッジ: `uv tool run diff-cover coverage.xml --compare-branch origin/main`（100%）
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: なし
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した（ToDo なし）
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている（変更なし）
- [x] Issue 自動クローズ用に `Close #<番号>` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した（未実施）
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した（今回はコード・テストのみ）
- [ ] 生成物（PDF など）がある場合は添付または参照先を明記した（該当なし）
- [x] PR 本文中の `Close #<番号>` や `docs/todo/…` などのプレースホルダをすべて実際の値に置き換えた