### PR TITLE
fix: RM-000 api env validation

### DIFF
--- a/src/pptx_generator/api/flask_app.py
+++ b/src/pptx_generator/api/flask_app.py
@@ -14,6 +14,7 @@ def create_app() -> Flask:
     app = Flask(__name__)
 
     logger = configure_api_logging(os.environ.get("LOG_LEVEL", "INFO"))
+    _validate_required_env(logger)
     app.config["API_LOGGER"] = logger
     app.config["HMAC_KEYS"] = _load_hmac_keys()
     app.config["HMAC_SKEW_SEC"] = int(os.environ.get("PPTX_API_HMAC_CLOCK_SKEW_SEC", "300"))
@@ -39,3 +40,18 @@ def _load_hmac_keys() -> list[str]:
     if next_key:
         keys.append(next_key)
     return keys
+
+
+def _validate_required_env(logger) -> None:
+    missing: list[str] = []
+    output_root = os.environ.get("PPTX_OUTPUT_ROOT")
+    if not output_root:
+        missing.append("PPTX_OUTPUT_ROOT")
+    bearer = os.environ.get("PPTX_API_BEARER_TOKEN")
+    hmac_current = os.environ.get("PPTX_API_HMAC_KEY_CURRENT")
+    if not bearer and not hmac_current:
+        missing.append("PPTX_API_BEARER_TOKEN or PPTX_API_HMAC_KEY_CURRENT")
+    if missing:
+        message = f"missing required environment variables: {', '.join(missing)}"
+        logger.error(message)
+        raise RuntimeError(message)

--- a/tests/api/test_flask_app.py
+++ b/tests/api/test_flask_app.py
@@ -8,12 +8,33 @@ import pytest
 from pptx_generator.api.flask_app import create_app
 
 
-@pytest.fixture
-def client(monkeypatch):
-    monkeypatch.delenv("PPTX_API_BEARER_TOKEN", raising=False)
+@pytest.fixture(autouse=True)
+def api_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("PPTX_OUTPUT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PPTX_API_BEARER_TOKEN", "token-123")
     monkeypatch.delenv("PPTX_API_HMAC_KEY_CURRENT", raising=False)
+    return tmp_path
+
+
+@pytest.fixture
+def client():
     app = create_app()
     return app.test_client()
+
+
+def test_create_app_missing_output_root(monkeypatch):
+    monkeypatch.delenv("PPTX_OUTPUT_ROOT", raising=False)
+    with pytest.raises(RuntimeError) as exc:
+        create_app()
+    assert "PPTX_OUTPUT_ROOT" in str(exc.value)
+
+
+def test_create_app_missing_auth(monkeypatch):
+    monkeypatch.delenv("PPTX_API_BEARER_TOKEN", raising=False)
+    monkeypatch.delenv("PPTX_API_HMAC_KEY_CURRENT", raising=False)
+    with pytest.raises(RuntimeError) as exc:
+        create_app()
+    assert "PPTX_API_BEARER_TOKEN or PPTX_API_HMAC_KEY_CURRENT" in str(exc.value)
 
 
 def test_auth_missing_returns_401(client):
@@ -104,15 +125,6 @@ def test_hmac_load_keys(monkeypatch):
 
 
 def test_job_flow_status(monkeypatch, tmp_path):
-    monkeypatch.delenv("PPTX_API_BEARER_TOKEN", raising=False)
-    monkeypatch.delenv("PPTX_API_HMAC_KEY_CURRENT", raising=False)
-    app = create_app()
-    c = app.test_client()
-    resp = c.post("/templates", json={"template_path": "x", "mode": "static"})
-    assert resp.status_code == 401
-
-    monkeypatch.setenv("PPTX_API_BEARER_TOKEN", "token-123")
-    monkeypatch.setenv("PPTX_OUTPUT_ROOT", str(tmp_path))
     app = create_app()
     c = app.test_client()
     resp = c.post(
@@ -677,11 +689,6 @@ def test_gen_artifact_download(monkeypatch, tmp_path):
 def test_output_root_default(monkeypatch, tmp_path):
     monkeypatch.setenv("PPTX_API_BEARER_TOKEN", "token-123")
     monkeypatch.delenv("PPTX_OUTPUT_ROOT", raising=False)
-    app = create_app()
-    c = app.test_client()
-    resp = c.post(
-        "/templates",
-        headers={"Authorization": "Bearer token-123"},
-        json={"template_path": "samples/templates/templates.pptx", "mode": "dynamic"},
-    )
-    assert resp.status_code == 422
+    with pytest.raises(RuntimeError) as exc:
+        create_app()
+    assert "PPTX_OUTPUT_ROOT" in str(exc.value)


### PR DESCRIPTION
## 概要
- Flask API 起動時に必須環境変数（PPTX_OUTPUT_ROOT と 認証用いずれか）が未設定なら起動失敗させ、ログで不足を明示するようにしました。
- 起動前検証のテストを追加し、既存のテストフィクスチャを起動要件に合わせて整理しました。

## 関連リンク
- Issue Close: Close #458
- ToDo: なし（今回のタスクは ToDo/RM 作成不要との指示）
- ノート／設計資料: なし

## 変更内容
- `create_app` 内で `_validate_required_env` を呼び出し、`PPTX_OUTPUT_ROOT` と `PPTX_API_BEARER_TOKEN`/`PPTX_API_HMAC_KEY_CURRENT` をチェック。
- 足りない環境変数をエラーログ出力して `RuntimeError` で起動を止める処理を追加。
- Flask API テストフィクスチャを共通化し、必須環境変数未設定時の起動失敗テストを追加。

## ユーザー影響
- 必須環境変数が未設定のまま起動すると即時エラーで気づけるようになり、リクエスト受信後の 401/422 まで進まなくなります。
- 影響確認: 必須 env を外して `uv run flask --app pptx_generator.api.flask_app:create_app run` すると起動前に RuntimeError が発生することを確認してください。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest`
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: なし
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した（今回 ToDo なし）
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている（該当更新なし）
- [x] Issue 自動クローズ用に `Close #<番号>` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した（該当なし）
- [ ] 生成物（PDF など）がある場合は添付または参照先を明記した
- [x] PR 本文中の `Close #<番号>` や `docs/todo/…` などのプレースホルダをすべて実際の値に置き換えた