### PR TITLE
fix: RM-000 config manager priority naming

### DIFF
--- a/src/pptx_generator/config_manager.py
+++ b/src/pptx_generator/config_manager.py
@@ -23,7 +23,7 @@ class ResolvedConfig:
 class ConfigManager:
     """複数の設定ソースを優先度付きで扱うマネージャ。"""
 
-    PRIORITY_ORDER: PriorityOrder = (
+    DEFAULT_PRIORITY: PriorityOrder = (
         "cli_options",
         "env_variables",
         "project_config",
@@ -32,7 +32,7 @@ class ConfigManager:
     )
 
     def __init__(self, priority_order: PriorityOrder | None = None) -> None:
-        self.priority_order: PriorityOrder = priority_order or self.PRIORITY_ORDER
+        self.priority_order: PriorityOrder = priority_order or self.DEFAULT_PRIORITY
         self._sources: dict[str, dict[str, Any]] = {name: {} for name in self.priority_order}
         self._resolved: dict[str, Any] = {}
         self._resolved_sources: dict[str, str] = {}


### PR DESCRIPTION
## 概要
- ConfigManager のデフォルト優先度定義を `DEFAULT_PRIORITY` にリネームし、インスタンス属性 `priority_order` との大文字小文字衝突による Sonar BLOCKER (python:S1845) を解消しました。
- 影響は設定優先度の定義と利用箇所のみで、外部インターフェースの挙動は変わりません。

## 関連リンク
- Issue Close: #465
- ToDo: N/A（今回のタスクでは ToDo 作成不要）
- ノート／設計資料: N/A

## 変更内容
- ConfigManager のクラス定数を `PRIORITY_ORDER` から `DEFAULT_PRIORITY` に改名し、命名衝突を解消。
- 関連参照の更新のみで、機能仕様や入出力の変更なし。

## ユーザー影響
- 外部API・CLIの挙動変更なし。設定優先度のデフォルトが明確化されるのみ。
- Sonar BLOCKER の解消により品質ゲートが改善します。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest`
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: N/A
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した（ToDo なし）
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている（今回対象外）
- [x] Issue 自動クローズ用に `Close #465` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した（必要に応じて実施）
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した（変更なし）
- [x] 生成物（PDF など）がある場合は添付または参照先を明記した（生成物なし）
- [x] PR 本文中の `Close #465` や `docs/todo/…` などのプレースホルダをすべて実際の値に置き換えた
