### PR TITLE
fix: RM-466 ensure stage artifacts refresh registry

### DIFF
--- a/src/pptx_generator/api/routes.py
+++ b/src/pptx_generator/api/routes.py
@@ -455,33 +455,42 @@ def _latest_job(queue: InProcessJobQueue, transaction_id: str, stage: str):
 def _ensure_stage_artifacts(
     queue: InProcessJobQueue, tx_root: Path, transaction_id: str, stage: str, keys: list[str], allow_missing: bool = False
 ) -> dict[str, str]:
-    registry = _load_registry(tx_root) or {}
-    entry = registry.get(stage)
-    if entry is None:
-        state = _latest_job(queue, transaction_id, stage)
-        if state is not None and state.status not in (JobStatus.SUCCEEDED, JobStatus.FAILED):
-            queue.wait(state.request.job_id)
-            state = queue.get_job(state.request.job_id)  # type: ignore[attr-defined]
-        if state is not None and state.status == JobStatus.SUCCEEDED:
+    registry = _load_registry(tx_root)
+    entry = registry.get(stage) if registry else None
+
+    state = _latest_job(queue, transaction_id, stage)
+    if state is not None and state.status not in (JobStatus.SUCCEEDED, JobStatus.FAILED):
+        queue.wait(state.request.job_id)
+        state = queue.get_job(state.request.job_id)  # type: ignore[attr-defined]
+    if state is not None and state.status == JobStatus.SUCCEEDED:
+        current_job_id = entry.get("job_id") if isinstance(entry, dict) else None
+        if entry is None or current_job_id != state.request.job_id:
             _update_registry(tx_root, stage, state)
-            entry = {"artifacts": state.result.get("artifacts") if isinstance(state.result, dict) else {}}
-        elif state is not None and state.status == JobStatus.FAILED:
-            resp = jsonify({"code": "validation_error", "message": f"{stage} artifacts not found"})
-            resp.status_code = 422
-            abort(resp)
-    if registry is None and entry is None:
+            registry = _load_registry(tx_root)
+            entry = registry.get(stage) if registry else None
+    elif entry is None and state is not None and state.status == JobStatus.FAILED:
+        resp = jsonify({"code": "validation_error", "message": f"{stage} artifacts not found"})
+        resp.status_code = 422
+        abort(resp)
+
+    if entry is None:
         if allow_missing:
             return {}
-        resp = jsonify({"code": "not_found", "message": "transaction not found"})
-        resp.status_code = 404
+        if registry is None:
+            resp = jsonify({"code": "not_found", "message": "transaction not found"})
+            resp.status_code = 404
+            abort(resp)
+        resp = jsonify({"code": "validation_error", "message": f"{stage} artifacts not found"})
+        resp.status_code = 422
         abort(resp)
-    if not entry or "artifacts" not in entry:
+    if not isinstance(entry, dict) or "artifacts" not in entry:
         if allow_missing:
             return {}
         resp = jsonify({"code": "validation_error", "message": f"{stage} artifacts not found"})
         resp.status_code = 422
         abort(resp)
-    artifacts = entry.get("artifacts") if isinstance(entry, dict) else None
+
+    artifacts = entry.get("artifacts")
     if not artifacts:
         if allow_missing:
             return {}

--- a/tests/api/test_stage_artifacts.py
+++ b/tests/api/test_stage_artifacts.py
@@ -1,0 +1,154 @@
+import json
+
+import pytest
+from werkzeug.exceptions import HTTPException
+
+from pptx_generator.api.flask_app import create_app
+from pptx_generator.api.routes import _ensure_stage_artifacts, _registry_path
+from pptx_generator.runtime.job_queue import InProcessJobQueue, JobRequest, JobState, JobStatus
+from datetime import datetime, timezone
+
+
+@pytest.fixture
+def api_app(monkeypatch, tmp_path):
+    monkeypatch.setenv("PPTX_OUTPUT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PPTX_API_BEARER_TOKEN", "token-123")
+    monkeypatch.delenv("PPTX_API_HMAC_KEY_CURRENT", raising=False)
+    return create_app()
+
+
+def test_ensure_stage_artifacts_returns_404_when_transaction_missing(api_app, tmp_path):
+    queue = InProcessJobQueue()
+    with api_app.app_context(), pytest.raises(HTTPException) as excinfo:
+        _ensure_stage_artifacts(queue, tmp_path, "tx-1", "template", ["jobspec_url"])
+    assert excinfo.value.response.status_code == 404
+
+
+def test_ensure_stage_artifacts_allows_missing_flag(api_app, tmp_path):
+    queue = InProcessJobQueue()
+    with api_app.app_context():
+        resolved = _ensure_stage_artifacts(
+            queue, tmp_path, "tx-2", "template", ["jobspec_url"], allow_missing=True
+        )
+    assert resolved == {}
+
+
+def test_ensure_stage_artifacts_returns_422_when_stage_not_in_registry(api_app, tmp_path):
+    registry_path = _registry_path(tmp_path)
+    registry_path.write_text(json.dumps({"other": {"artifacts": {}}}), encoding="utf-8")
+    queue = InProcessJobQueue()
+    with api_app.app_context(), pytest.raises(HTTPException) as excinfo:
+        _ensure_stage_artifacts(queue, tmp_path, "tx-3", "template", ["jobspec_url"])
+    assert excinfo.value.response.status_code == 422
+
+
+def test_ensure_stage_artifacts_requires_artifacts_field(api_app, tmp_path):
+    registry_path = _registry_path(tmp_path)
+    registry_path.write_text(json.dumps({"template": {"job_id": "123"}}, ensure_ascii=False), encoding="utf-8")
+    queue = InProcessJobQueue()
+    with api_app.app_context(), pytest.raises(HTTPException) as excinfo:
+        _ensure_stage_artifacts(queue, tmp_path, "tx-4", "template", ["jobspec_url"])
+    assert excinfo.value.response.status_code == 422
+
+
+def test_ensure_stage_artifacts_loads_latest_job_success(api_app, tmp_path):
+    queue = InProcessJobQueue()
+    artifacts = {"jobspec_url": "artifacts/jobspec.json"}
+    request = JobRequest(stage="template", func=lambda: None, transaction_id="tx-5")
+    state = JobState(
+        request=request,
+        status=JobStatus.SUCCEEDED,
+        result={"artifacts": artifacts},
+        finished_at=datetime.now(timezone.utc),
+    )
+    queue._jobs[request.job_id] = state  # type: ignore[attr-defined]
+
+    with api_app.app_context():
+        resolved = _ensure_stage_artifacts(queue, tmp_path, "tx-5", "template", ["jobspec_url"])
+
+    assert resolved["jobspec_url"] == str((tmp_path / artifacts["jobspec_url"]).resolve())
+
+
+def test_registry_updates_with_newer_job(api_app, tmp_path):
+    queue = InProcessJobQueue()
+    tx_id = "tx-6"
+    old_request = JobRequest(stage="template", func=lambda: None, transaction_id=tx_id, job_id="old-job")
+    new_request = JobRequest(stage="template", func=lambda: None, transaction_id=tx_id, job_id="new-job")
+
+    old_state = JobState(
+        request=old_request,
+        status=JobStatus.SUCCEEDED,
+        result={"artifacts": {"jobspec_url": str(tmp_path / "template" / "old.json")}},
+        finished_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+    new_state = JobState(
+        request=new_request,
+        status=JobStatus.SUCCEEDED,
+        result={"artifacts": {"jobspec_url": str(tmp_path / "template" / "new.json")}},
+        finished_at=datetime(2025, 1, 2, tzinfo=timezone.utc),
+    )
+    queue._jobs[old_request.job_id] = old_state  # type: ignore[attr-defined]
+    queue._jobs[new_request.job_id] = new_state  # type: ignore[attr-defined]
+
+    # 旧ジョブで一度 registry を作成
+    _ensure_stage_artifacts(queue, tmp_path, tx_id, "template", ["jobspec_url"])
+
+    # 新しいジョブが最新として後勝ちで反映されることを確認
+    with api_app.app_context():
+        resolved = _ensure_stage_artifacts(queue, tmp_path, tx_id, "template", ["jobspec_url"])
+
+    assert resolved["jobspec_url"].endswith("template/new.json")
+    registry = json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))
+    assert registry["template"]["job_id"] == "new-job"
+
+
+def test_pending_job_waits_and_updates_registry(api_app, tmp_path):
+    request = JobRequest(stage="template", func=lambda: None, transaction_id="tx-7", job_id="pending-job")
+    state = JobState(
+        request=request,
+        status=JobStatus.PENDING,
+        result=None,
+        finished_at=None,
+    )
+
+    class DummyQueue(InProcessJobQueue):  # type: ignore[misc]
+        def __init__(self, initial_state):
+            super().__init__()
+            self._jobs[initial_state.request.job_id] = initial_state  # type: ignore[attr-defined]
+
+        def wait(self, job_id: str, timeout: float | None = None):
+            job_state = self._jobs[job_id]  # type: ignore[attr-defined]
+            job_state.status = JobStatus.SUCCEEDED
+            job_state.result = {"artifacts": {"jobspec_url": "template/pending.json"}}
+            job_state.finished_at = datetime.now(timezone.utc)
+            job_state.done.set()
+            return job_state
+
+        def get_job(self, job_id: str):
+            return self._jobs.get(job_id)  # type: ignore[attr-defined]
+
+    queue = DummyQueue(state)
+
+    with api_app.app_context():
+        resolved = _ensure_stage_artifacts(queue, tmp_path, "tx-7", "template", ["jobspec_url"])
+
+    assert resolved["jobspec_url"].endswith("template/pending.json")
+    registry = json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))
+    assert registry["template"]["job_id"] == "pending-job"
+
+
+def test_failed_latest_job_without_entry_returns_422(api_app, tmp_path):
+    request = JobRequest(stage="template", func=lambda: None, transaction_id="tx-8", job_id="failed-job")
+    state = JobState(
+        request=request,
+        status=JobStatus.FAILED,
+        result=None,
+        finished_at=datetime.now(timezone.utc),
+    )
+    queue = InProcessJobQueue()
+    queue._jobs[request.job_id] = state  # type: ignore[attr-defined]
+
+    with api_app.app_context(), pytest.raises(HTTPException) as excinfo:
+        _ensure_stage_artifacts(queue, tmp_path, "tx-8", "template", ["jobspec_url"])
+
+    assert excinfo.value.response.status_code == 422


### PR DESCRIPTION
## 概要
- Sonar 指摘の None アクセス経路を解消し、ステージ artifacts の解決を後勝ちで安全にする。
- 最新ジョブ成功時は registry.json を常に更新し、失敗／未登録時の応答を明示。

## 関連リンク
- Issue Close: #466
- ToDo: 該当なし（ユーザー指定により未作成）
- ノート／設計資料: なし

## 変更内容
- `_ensure_stage_artifacts` を最新ジョブに基づく後勝ち更新に整理し、失敗時の 422 応答や allow_missing 動作を明確化。
- ステージ成果物取得の後勝ち更新、pending 待機、失敗 422 などをカバーするテストを追加。

## ユーザー影響
- 同一ステージを再実行した際、最新ジョブの成果物で確実に参照・更新され、None アクセスによる 500 リスクが低減。
- 確認方法:
  - 同一 transaction/stage でジョブを複数回実行し、registry.json の job_id/artifacts が最新に更新されることを確認。
  - 失敗ジョブのみの場合は 422 が返ることを確認。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest tests/api/test_stage_artifacts.py`
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: なし
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている
- [x] Issue 自動クローズ用に `Close #<番号>` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した
- [ ] 生成物（PDF など）がある場合は添付または参照先を明記した
- [x] PR 本文中の `Close #<番号>` や `docs/todo/…` などのプレースホルダをすべて実際の値に置き換えた