### PR TITLE
fix: RM-000 guard stage artifacts lookups

### DIFF
--- a/src/pptx_generator/api/routes.py
+++ b/src/pptx_generator/api/routes.py
@@ -472,6 +472,7 @@ def _ensure_stage_artifacts(
         resp = jsonify({"code": "validation_error", "message": f"{stage} artifacts not found"})
         resp.status_code = 422
         abort(resp)
+        return {}
 
     if entry is None:
         if allow_missing:
@@ -480,15 +481,18 @@ def _ensure_stage_artifacts(
             resp = jsonify({"code": "not_found", "message": "transaction not found"})
             resp.status_code = 404
             abort(resp)
+            return {}
         resp = jsonify({"code": "validation_error", "message": f"{stage} artifacts not found"})
         resp.status_code = 422
         abort(resp)
+        return {}
     if not isinstance(entry, dict) or "artifacts" not in entry:
         if allow_missing:
             return {}
         resp = jsonify({"code": "validation_error", "message": f"{stage} artifacts not found"})
         resp.status_code = 422
         abort(resp)
+        return {}
 
     artifacts = entry.get("artifacts")
     if not artifacts:
@@ -497,6 +501,7 @@ def _ensure_stage_artifacts(
         resp = jsonify({"code": "validation_error", "message": f"{stage} artifacts not found"})
         resp.status_code = 422
         abort(resp)
+        return {}
     resolved = {}
     for key in keys:
         path = artifacts.get(key)
@@ -504,5 +509,6 @@ def _ensure_stage_artifacts(
             resp = jsonify({"code": "validation_error", "message": f"{stage} artifacts not found"})
             resp.status_code = 422
             abort(resp)
+            return {}
         resolved[key] = str((tx_root / path).resolve())
     return resolved


### PR DESCRIPTION
## 概要
- SonarCloud の新コード信頼性 C (Bug: pythonbugs:S2259) を解消するため、`_ensure_stage_artifacts` の None ガードを早期 return で明示し、`entry.get("artifacts")` への到達可能性を遮断しました。
- ローカルで pytest を完走し、挙動に問題がないことを確認しています。CI/Sonar で Quality Gate が通ることを期待しています。

## 関連リンク
- Issue Close: #466
- ToDo: なし（ユーザー指示で ToDo 作成スキップ）
- ノート／設計資料: なし

## 変更内容
- `src/pptx_generator/api/routes.py` の `_ensure_stage_artifacts` で abort 後に return を追加し、None/非 dict/欠落キーのパスを早期終了させるリファクタ。
- ローカルテスト `uv run --extra dev pytest` を実行し、成功を確認。

## ユーザー影響
- 取引ステージのアーティファクト取得処理で None ガードを強化し、例外経路を安全化。
- 確認方法: `uv run --extra dev pytest` が成功すること、SonarCloud の Quality Gate が Passed になることを確認。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest`
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: なし
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した（ToDo なし）
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている（変更なし）
- [x] Issue 自動クローズ用に `Close #<番号>` を PR 本文へ記載した
- [x] Issue に進捗コメント（またはクローズコメント）を残した
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した（対象なし）
- [x] 生成物（PDF など）がある場合は添付または参照先を明記した（対象なし）
- [x] PR 本文中の `Close #<番号>` や `docs/todo/…` などのプレースホルダをすべて実際の値に置き換えた
