### PR TITLE
fix: RM-094 job-queue-exception-handling

### DIFF
--- a/src/pptx_generator/runtime/job_queue.py
+++ b/src/pptx_generator/runtime/job_queue.py
@@ -68,12 +68,13 @@ class InProcessJobQueue:
                 job_id = self._queue.get(timeout=1.0)
             except Empty:
                 continue
-            state = self._jobs.get(job_id)
-            if state is None:
+            try:
+                state = self._jobs.get(job_id)
+                if state is None:
+                    continue
+                self._run_job(state)
+            finally:
                 self._queue.task_done()
-                continue
-            self._run_job(state)
-            self._queue.task_done()
 
     def _run_job(self, state: JobState[object]) -> None:
         state.status = JobStatus.RUNNING
@@ -82,9 +83,13 @@ class InProcessJobQueue:
         try:
             state.result = state.request.func()
             state.status = JobStatus.SUCCEEDED
+        except Exception as exc:
+            state.error = exc
+            state.status = JobStatus.FAILED
         except BaseException as exc:  # noqa: BLE001
             state.error = exc
             state.status = JobStatus.FAILED
+            raise
         finally:
             reset_current_job(token)
             state.finished_at = datetime.now(timezone.utc)

--- a/tests/runtime/test_job_queue.py
+++ b/tests/runtime/test_job_queue.py
@@ -48,3 +48,16 @@ def test_run_job_sync_raises_exceptions(tmp_path) -> None:
     queue = get_queue()
     job_states = [state for state in queue._jobs.values()]  # type: ignore[attr-defined]
     assert any(state.status == JobStatus.FAILED for state in job_states)
+
+
+def test_run_job_sync_reraises_base_exception(tmp_path) -> None:
+    def task() -> None:
+        _ = PipelineContext(spec=_build_stub_spec(), workdir=tmp_path)
+        raise KeyboardInterrupt()
+
+    with pytest.raises(KeyboardInterrupt):
+        run_job_sync(stage="gen", func=task)
+
+    queue = get_queue()
+    job_states = [state for state in queue._jobs.values()]  # type: ignore[attr-defined]
+    assert any(state.status == JobStatus.FAILED for state in job_states)


### PR DESCRIPTION
## 概要
- job_queue で広すぎる例外捕捉を修正し、予期しない BaseException を握り潰さないようにしました。
- Issue #477 対応。

## 関連リンク
- Issue Close: Close #477
- ToDo: なし
- ノート／設計資料: なし

## 変更内容
- `_run_job` で `Exception` のみ捕捉し、`BaseException` 系は記録したうえで再スローするように修正。
- `_worker_loop` で `task_done()` 呼び出しを `finally` に移動し、キュー整合性を保証。
- `KeyboardInterrupt` が再スローされることを確認するテストを追加。

## ユーザー影響
- ジョブ実行中に予期しない例外が握り潰されず、失敗が検知されるようになります。
- 確認方法: `uv run --extra dev pytest tests/runtime/test_job_queue.py` で例外伝搬のテストが通ること。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest tests/runtime/test_job_queue.py`
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: 不要
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した（ToDoなし）
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている（今回変更なし）
- [x] Issue 自動クローズ用に `Close #<番号>` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した（未実施）
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した（変更なし）
- [ ] 生成物（PDF など）がある場合は添付または参照先を明記した（対象なし）
- [x] PR 本文中の `Close #<番号>` や `docs/todo/…` などのプレースホルダをすべて実際の値に置き換えた