### PR TITLE
fix: RM-000 stage artifacts handling

### DIFF
--- a/src/pptx_generator/api/routes.py
+++ b/src/pptx_generator/api/routes.py
@@ -27,6 +27,7 @@ from pptx_generator.api.stages import (
 from pptx_generator.runtime.job_queue import (
     JobRequest,
     JobStatus,
+    JobState,
     InProcessJobQueue,
     get_queue,
 )
@@ -532,63 +533,88 @@ def _latest_job(queue: InProcessJobQueue, transaction_id: str, stage: str):
     return latest
 
 
+def _abort_response(status_code: int, code: str, message: str) -> None:
+    resp = jsonify({"code": code, "message": message})
+    resp.status_code = status_code
+    abort(resp)
+
+
+def _abort_transaction_not_found() -> None:
+    _abort_response(404, "not_found", "transaction not found")
+
+
+def _abort_stage_artifacts_not_found(stage: str) -> None:
+    _abort_response(422, "validation_error", f"{stage} artifacts not found")
+
+
+def _await_latest_state(queue: InProcessJobQueue, state: JobState | None) -> JobState | None:
+    if state is None:
+        return None
+    if state.status not in (JobStatus.SUCCEEDED, JobStatus.FAILED):
+        queue.wait(state.request.job_id)
+        return queue.get_job(state.request.job_id)  # type: ignore[attr-defined]
+    return state
+
+
+def _refresh_registry_from_state(
+    tx_root: Path, stage: str, entry: dict | None, registry: dict | None, state: JobState | None
+) -> tuple[dict | None, dict | None]:
+    if state is None:
+        return entry, registry
+    if state.status == JobStatus.SUCCEEDED:
+        current_job_id = entry.get("job_id") if isinstance(entry, dict) else None
+        if entry is None or current_job_id != state.request.job_id:
+            _update_registry(tx_root, stage, state)
+            registry = _load_registry(tx_root)
+            entry = registry.get(stage) if registry else None
+        return entry, registry
+    if entry is None and state.status == JobStatus.FAILED:
+        _abort_stage_artifacts_not_found(stage)
+    return entry, registry
+
+
+def _handle_missing_entry(allow_missing: bool, registry: dict | None, stage: str) -> dict[str, str]:
+    if allow_missing:
+        return {}
+    if registry is None:
+        _abort_transaction_not_found()
+    _abort_stage_artifacts_not_found(stage)
+    return {}
+
+
+def _extract_artifacts(entry: dict | None, allow_missing: bool, stage: str) -> dict:
+    if not isinstance(entry, dict):
+        return _handle_missing_entry(allow_missing, {}, stage)
+    artifacts = entry.get("artifacts")
+    if artifacts:
+        return artifacts
+    return _handle_missing_entry(allow_missing, {}, stage)
+
+
+def _resolve_artifacts_paths(tx_root: Path, artifacts: dict, stage: str, keys: list[str]) -> dict[str, str]:
+    resolved = {}
+    for key in keys:
+        path = artifacts.get(key)
+        if not path:
+            _abort_stage_artifacts_not_found(stage)
+        resolved[key] = str((tx_root / path).resolve())
+    return resolved
+
+
 def _ensure_stage_artifacts(
     queue: InProcessJobQueue, tx_root: Path, transaction_id: str, stage: str, keys: list[str], allow_missing: bool = False
 ) -> dict[str, str]:
     registry = _load_registry(tx_root)
     entry = registry.get(stage) if registry else None
 
-    state = _latest_job(queue, transaction_id, stage)
-    if state is not None and state.status not in (JobStatus.SUCCEEDED, JobStatus.FAILED):
-        queue.wait(state.request.job_id)
-        state = queue.get_job(state.request.job_id)  # type: ignore[attr-defined]
-    if state is not None and state.status == JobStatus.SUCCEEDED:
-        current_job_id = entry.get("job_id") if isinstance(entry, dict) else None
-        if entry is None or current_job_id != state.request.job_id:
-            _update_registry(tx_root, stage, state)
-            registry = _load_registry(tx_root)
-            entry = registry.get(stage) if registry else None
-    elif entry is None and state is not None and state.status == JobStatus.FAILED:
-        resp = jsonify({"code": "validation_error", "message": f"{stage} artifacts not found"})
-        resp.status_code = 422
-        abort(resp)
-        return {}
+    state = _await_latest_state(queue, _latest_job(queue, transaction_id, stage))
+    entry, registry = _refresh_registry_from_state(tx_root, stage, entry, registry, state)
 
     if entry is None:
-        if allow_missing:
-            return {}
-        if registry is None:
-            resp = jsonify({"code": "not_found", "message": "transaction not found"})
-            resp.status_code = 404
-            abort(resp)
-            return {}
-        resp = jsonify({"code": "validation_error", "message": f"{stage} artifacts not found"})
-        resp.status_code = 422
-        abort(resp)
-        return {}
-    if not isinstance(entry, dict) or "artifacts" not in entry:
-        if allow_missing:
-            return {}
-        resp = jsonify({"code": "validation_error", "message": f"{stage} artifacts not found"})
-        resp.status_code = 422
-        abort(resp)
+        return _handle_missing_entry(allow_missing, registry, stage)
+
+    artifacts = _extract_artifacts(entry, allow_missing, stage)
+    if not artifacts:
         return {}
 
-    artifacts = entry.get("artifacts")
-    if not artifacts:
-        if allow_missing:
-            return {}
-        resp = jsonify({"code": "validation_error", "message": f"{stage} artifacts not found"})
-        resp.status_code = 422
-        abort(resp)
-        return {}
-    resolved = {}
-    for key in keys:
-        path = artifacts.get(key)
-        if not path:
-            resp = jsonify({"code": "validation_error", "message": f"{stage} artifacts not found"})
-            resp.status_code = 422
-            abort(resp)
-            return {}
-        resolved[key] = str((tx_root / path).resolve())
-    return resolved
+    return _resolve_artifacts_paths(tx_root, artifacts, stage, keys)

--- a/tests/api/test_stage_artifacts.py
+++ b/tests/api/test_stage_artifacts.py
@@ -33,6 +33,17 @@ def test_ensure_stage_artifacts_allows_missing_flag(api_app, tmp_path):
     assert resolved == {}
 
 
+def test_allow_missing_returns_empty_when_entry_has_no_artifacts(api_app, tmp_path):
+    registry_path = _registry_path(tmp_path)
+    registry_path.write_text(json.dumps({"template": {"job_id": "123"}}, ensure_ascii=False), encoding="utf-8")
+    queue = InProcessJobQueue()
+    with api_app.app_context():
+        resolved = _ensure_stage_artifacts(
+            queue, tmp_path, "tx-2a", "template", ["jobspec_url"], allow_missing=True
+        )
+    assert resolved == {}
+
+
 def test_ensure_stage_artifacts_returns_422_when_stage_not_in_registry(api_app, tmp_path):
     registry_path = _registry_path(tmp_path)
     registry_path.write_text(json.dumps({"other": {"artifacts": {}}}), encoding="utf-8")
@@ -48,6 +59,36 @@ def test_ensure_stage_artifacts_requires_artifacts_field(api_app, tmp_path):
     queue = InProcessJobQueue()
     with api_app.app_context(), pytest.raises(HTTPException) as excinfo:
         _ensure_stage_artifacts(queue, tmp_path, "tx-4", "template", ["jobspec_url"])
+    assert excinfo.value.response.status_code == 422
+
+
+def test_missing_requested_artifact_key_returns_422(api_app, tmp_path):
+    registry_path = _registry_path(tmp_path)
+    registry_path.write_text(
+        json.dumps({"template": {"artifacts": {"jobspec_url": "template/job.json"}}}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    queue = InProcessJobQueue()
+    with api_app.app_context(), pytest.raises(HTTPException) as excinfo:
+        _ensure_stage_artifacts(queue, tmp_path, "tx-4a", "template", ["prepare_card_url"])
+    assert excinfo.value.response.status_code == 422
+
+
+def test_entry_not_dict_returns_empty_when_allow_missing(api_app, tmp_path):
+    registry_path = _registry_path(tmp_path)
+    registry_path.write_text(json.dumps({"template": []}, ensure_ascii=False), encoding="utf-8")
+    queue = InProcessJobQueue()
+    with api_app.app_context():
+        resolved = _ensure_stage_artifacts(queue, tmp_path, "tx-4b", "template", ["jobspec_url"], allow_missing=True)
+    assert resolved == {}
+
+
+def test_entry_not_dict_returns_422_when_not_allow_missing(api_app, tmp_path):
+    registry_path = _registry_path(tmp_path)
+    registry_path.write_text(json.dumps({"template": []}, ensure_ascii=False), encoding="utf-8")
+    queue = InProcessJobQueue()
+    with api_app.app_context(), pytest.raises(HTTPException) as excinfo:
+        _ensure_stage_artifacts(queue, tmp_path, "tx-4c", "template", ["jobspec_url"])
     assert excinfo.value.response.status_code == 422
 
 
@@ -152,3 +193,31 @@ def test_failed_latest_job_without_entry_returns_422(api_app, tmp_path):
         _ensure_stage_artifacts(queue, tmp_path, "tx-8", "template", ["jobspec_url"])
 
     assert excinfo.value.response.status_code == 422
+
+
+def test_failed_latest_job_with_entry_without_artifacts_returns_422(api_app, tmp_path):
+    request = JobRequest(stage="template", func=lambda: None, transaction_id="tx-9", job_id="failed-job")
+    state = JobState(
+        request=request,
+        status=JobStatus.FAILED,
+        result=None,
+        finished_at=datetime.now(timezone.utc),
+    )
+    queue = InProcessJobQueue()
+    queue._jobs[request.job_id] = state  # type: ignore[attr-defined]
+
+    registry_path = _registry_path(tmp_path)
+    registry_path.write_text(json.dumps({"template": {"job_id": "old-job"}}, ensure_ascii=False), encoding="utf-8")
+
+    with api_app.app_context(), pytest.raises(HTTPException) as excinfo:
+        _ensure_stage_artifacts(queue, tmp_path, "tx-9", "template", ["jobspec_url"])
+
+    assert excinfo.value.response.status_code == 422
+
+
+def test_missing_registry_returns_404(api_app, tmp_path):
+    # registry file not created -> should return 404 when allow_missing is False
+    queue = InProcessJobQueue()
+    with api_app.app_context(), pytest.raises(HTTPException) as excinfo:
+        _ensure_stage_artifacts(queue, tmp_path, "tx-10", "template", ["jobspec_url"])
+    assert excinfo.value.response.status_code == 404


### PR DESCRIPTION
## 概要
- stage artifacts 取得処理の認知的複雑度を下げ、異常系のハンドリングを共通化しました。
- 失敗/未登録/欠落ケースで一貫したレスポンスを返すよう整理し、異常系テストを追加しました。

## 関連リンク
- Issue Close: #478
- ToDo: なし（今回タスクでは ToDo 作成不要）
- ノート／設計資料: なし

## 変更内容
- `_ensure_stage_artifacts` をヘルパー分割し、レスポンス生成・最新ジョブ待ち・レジストリ更新・パス解決を整理。
- レジストリ欠落/エントリ不正/キー欠落/最新ジョブ失敗などの異常系テストを追加。
- 差分カバレッジ 97% を確認。

## ユーザー影響
- API 異常時のレスポンスがより一貫し、分岐漏れによる 4xx/5xx ばらつきリスクを低減。
- 影響確認方法: `tests/api/test_stage_artifacts.py` の実行と、必要に応じて API 経由で artifacts 取得の異常系を手動確認。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド:
    - `uv run --extra dev pytest tests/api/test_stage_artifacts.py`
    - `uv tool run diff-cover coverage.xml --compare-branch origin/main`
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: なし
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した（ToDo なし）
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている（今回影響なし）
- [x] Issue 自動クローズ用に `Close #<番号>` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した（コードとテストのみ）
- [ ] 生成物（PDF など）がある場合は添付または参照先を明記した（対象なし）
- [x] PR 本文中の `Close #<番号>` や `docs/todo/…` などのプレースホルダをすべて実際の値に置き換えた