### PR TITLE
fix: RM-036 draft-intel-complexity

### DIFF
--- a/src/pptx_generator/draft_intel.py
+++ b/src/pptx_generator/draft_intel.py
@@ -131,47 +131,12 @@ def load_chapter_template(base_dir: Path, template_id: str) -> ChapterTemplate |
     if not isinstance(payload, dict):
         raise ValueError(f"テンプレートファイルの形式が不正です: {template_path}")
 
-    def _load_sections(items: Iterable[Mapping[str, object]]) -> list[ChapterTemplateSection]:
-        sections: list[ChapterTemplateSection] = []
-        for item in items:
-            section_id = str(item.get("id", "")).strip()
-            if not section_id:
-                continue
-            title = str(item.get("title", "")).strip() or None
-            min_slides = int(item.get("min_slides", 0) or 0)
-            max_value = item.get("max_slides")
-            max_slides: int | None = None
-            if isinstance(max_value, (int, float)):
-                max_slides = int(max_value)
-            sections.append(
-                ChapterTemplateSection(
-                    section_id=section_id,
-                    title=title,
-                    min_slides=min_slides,
-                    max_slides=max_slides,
-                )
-            )
-        return sections
-
     required_items = payload.get("required_sections") or []
     optional_items = payload.get("optional_sections") or []
     if not isinstance(required_items, list) or not isinstance(optional_items, list):
         raise ValueError(f"テンプレートのセクション定義が不正です: {template_path}")
 
-    constraints = payload.get("constraints") or {}
-    max_main_pages = None
-    appendix_policy = "overflow"
-    tags: tuple[str, ...] = ()
-    if isinstance(constraints, dict):
-        max_value = constraints.get("max_main_pages")
-        if isinstance(max_value, (int, float)) and max_value > 0:
-            max_main_pages = int(max_value)
-        appendix_policy_value = constraints.get("appendix_policy")
-        if isinstance(appendix_policy_value, str) and appendix_policy_value:
-            appendix_policy = appendix_policy_value
-        tags_value = constraints.get("tags")
-        if isinstance(tags_value, list):
-            tags = tuple(str(tag) for tag in tags_value if str(tag).strip())
+    max_main_pages, appendix_policy, tags = _parse_template_constraints(payload.get("constraints"))
 
     template = ChapterTemplate(
         template_id=str(payload.get("template_id") or template_path.stem),
@@ -200,80 +165,26 @@ def evaluate_chapter_template(
     normalized_counts = {key.lower(): count for key, count in section_counts.items()}
 
     for section in template.required_sections:
-        key = section.section_id.lower()
-        count = normalized_counts.get(key, 0)
-        score = 0.0
-        if count == 0:
-            mismatches.append(
-                DraftTemplateMismatch(
-                    section_id=section.section_id,
-                    issue="missing",
-                    severity="blocker",
-                    detail="必須章が不足しています",
-                )
-            )
-        else:
-            if section.max_slides is not None and count > section.max_slides:
-                mismatches.append(
-                    DraftTemplateMismatch(
-                        section_id=section.section_id,
-                        issue="excess",
-                        severity="warn",
-                        detail=f"許容枚数 {section.max_slides} を超過 (actual={count})",
-                    )
-                )
-                score = min(1.0, section.max_slides / count)
-            elif count < max(1, section.min_slides):
-                mismatches.append(
-                    DraftTemplateMismatch(
-                        section_id=section.section_id,
-                        issue="insufficient",
-                        severity="blocker",
-                        detail=f"必要枚数 {section.min_slides} 未満 (actual={count})",
-                    )
-                )
-                score = count / max(1, section.min_slides)
-            else:
-                score = 1.0
-                matched_required += 1
-        section_scores[section.section_id] = round(max(0.0, min(1.0, score)), 3)
+        count = normalized_counts.get(section.section_id.lower(), 0)
+        score, section_mismatches, matched = _score_required_section(section, count)
+        mismatches.extend(section_mismatches)
+        matched_required += matched
+        section_scores[section.section_id] = score
 
     for section in template.optional_sections:
-        key = section.section_id.lower()
-        count = normalized_counts.get(key, 0)
-        if count == 0:
-            section_scores.setdefault(section.section_id, 0.0)
-            continue
-        score = 1.0
-        if section.max_slides is not None and count > section.max_slides:
-            mismatches.append(
-                DraftTemplateMismatch(
-                    section_id=section.section_id,
-                    issue="excess",
-                    severity="warn",
-                    detail=f"任意章が許容枚数 {section.max_slides} を超過 (actual={count})",
-                )
-            )
-            score = min(1.0, section.max_slides / count)
-        section_scores[section.section_id] = round(max(0.0, min(1.0, score)), 3)
+        count = normalized_counts.get(section.section_id.lower(), 0)
+        score, section_mismatches = _score_optional_section(section, count)
+        mismatches.extend(section_mismatches)
+        section_scores[section.section_id] = score
 
-    if template.max_main_pages is not None and total_main_pages > template.max_main_pages:
-        severity = "blocker" if template.appendix_policy == "block" else "warn"
-        mismatches.append(
-            DraftTemplateMismatch(
-                section_id="__capacity__",
-                issue="capacity",
-                severity=severity,
-                detail=f"許容枚数 {template.max_main_pages} を超過 (actual={total_main_pages})",
-            )
-        )
+    capacity_mismatch = _capacity_mismatch(template, total_main_pages)
+    if capacity_mismatch:
+        mismatches.append(capacity_mismatch)
 
-    match_score = 1.0
-    if required_total:
-        match_score = max(0.0, min(1.0, matched_required / required_total))
+    match_score = _calculate_match_score(required_total, matched_required)
 
     return ChapterTemplateEvaluation(
-        match_score=round(match_score, 3),
+        match_score=match_score,
         section_scores=section_scores,
         mismatches=mismatches,
     )
@@ -289,41 +200,18 @@ def load_analysis_summary(path: Path) -> dict[str, DraftAnalyzerSummary]:
     payload = _load_json(path)
     if not isinstance(payload, dict):
         raise ValueError(f"analysis_summary.json の形式が不正です: {path}")
+
     slides = payload.get("slides")
     if not isinstance(slides, list):
         return {}
+
     summary: dict[str, DraftAnalyzerSummary] = {}
     for item in slides:
-        if not isinstance(item, dict):
+        parsed = _parse_slide_summary(item)
+        if parsed is None:
             continue
-        slide_uid = str(item.get("slide_uid", "")).strip()
-        if not slide_uid:
-            continue
-        severity_counts = item.get("severity_counts") or {}
-        high = int(severity_counts.get("high", 0) or 0)
-        medium = int(severity_counts.get("medium", 0) or 0)
-        low = int(severity_counts.get("low", 0) or 0)
-        layout_consistency = item.get("layout_consistency")
-        if isinstance(layout_consistency, str):
-            value = layout_consistency.lower()
-            if value in {"ok", "warn", "error"}:
-                layout_consistency = value
-            else:
-                layout_consistency = None
-        else:
-            layout_consistency = None
-        blocking_tags: tuple[str, ...] = ()
-        tags = item.get("blocking_tags")
-        if isinstance(tags, list):
-            blocking_tags = tuple(str(tag) for tag in tags if str(tag).strip())
-
-        summary[slide_uid] = DraftAnalyzerSummary(
-            severity_high=high,
-            severity_medium=medium,
-            severity_low=low,
-            layout_consistency=layout_consistency,
-            blocking_tags=blocking_tags,
-        )
+        slide_uid, analyzer_summary = parsed
+        summary[slide_uid] = analyzer_summary
     return summary
 
 
@@ -368,3 +256,168 @@ def clamp_score_detail(detail: DraftLayoutScoreDetail) -> DraftLayoutScoreDetail
         detail.analyzer_support = round(max(-0.5, detail.analyzer_support), 3)
         detail.ai_recommendation = round(max(0.0, detail.ai_recommendation), 3)
     return detail
+
+
+def _parse_template_constraints(constraints: object) -> tuple[int | None, str, tuple[str, ...]]:
+    max_main_pages = None
+    appendix_policy = "overflow"
+    tags: tuple[str, ...] = ()
+    if not isinstance(constraints, dict):
+        return max_main_pages, appendix_policy, tags
+
+    max_value = constraints.get("max_main_pages")
+    if isinstance(max_value, (int, float)) and max_value > 0:
+        max_main_pages = int(max_value)
+
+    appendix_policy_value = constraints.get("appendix_policy")
+    if isinstance(appendix_policy_value, str) and appendix_policy_value:
+        appendix_policy = appendix_policy_value
+
+    tags_value = constraints.get("tags")
+    if isinstance(tags_value, list):
+        tags = tuple(str(tag) for tag in tags_value if str(tag).strip())
+
+    return max_main_pages, appendix_policy, tags
+
+
+def _load_sections(items: Iterable[Mapping[str, object]]) -> list[ChapterTemplateSection]:
+    sections: list[ChapterTemplateSection] = []
+    for item in items:
+        section_id = str(item.get("id", "")).strip()
+        if not section_id:
+            continue
+        title = str(item.get("title", "")).strip() or None
+        min_slides = int(item.get("min_slides", 0) or 0)
+        max_value = item.get("max_slides")
+        max_slides: int | None = None
+        if isinstance(max_value, (int, float)):
+            max_slides = int(max_value)
+        sections.append(
+            ChapterTemplateSection(
+                section_id=section_id,
+                title=title,
+                min_slides=min_slides,
+                max_slides=max_slides,
+            )
+        )
+    return sections
+
+
+def _score_required_section(
+    section: ChapterTemplateSection, count: int
+) -> tuple[float, list[DraftTemplateMismatch], int]:
+    mismatches: list[DraftTemplateMismatch] = []
+    if count == 0:
+        mismatches.append(
+            DraftTemplateMismatch(
+                section_id=section.section_id,
+                issue="missing",
+                severity="blocker",
+                detail="必須章が不足しています",
+            )
+        )
+        return 0.0, mismatches, 0
+
+    if section.max_slides is not None and count > section.max_slides:
+        mismatches.append(
+            DraftTemplateMismatch(
+                section_id=section.section_id,
+                issue="excess",
+                severity="warn",
+                detail=f"許容枚数 {section.max_slides} を超過 (actual={count})",
+            )
+        )
+        return round(min(1.0, section.max_slides / count), 3), mismatches, 0
+
+    if count < max(1, section.min_slides):
+        mismatches.append(
+            DraftTemplateMismatch(
+                section_id=section.section_id,
+                issue="insufficient",
+                severity="blocker",
+                detail=f"必要枚数 {section.min_slides} 未満 (actual={count})",
+            )
+        )
+        score = count / max(1, section.min_slides)
+        return round(max(0.0, min(1.0, score)), 3), mismatches, 0
+
+    return 1.0, mismatches, 1
+
+
+def _score_optional_section(
+    section: ChapterTemplateSection, count: int
+) -> tuple[float, list[DraftTemplateMismatch]]:
+    if count == 0:
+        return 0.0, []
+
+    if section.max_slides is not None and count > section.max_slides:
+        mismatch = DraftTemplateMismatch(
+            section_id=section.section_id,
+            issue="excess",
+            severity="warn",
+            detail=f"任意章が許容枚数 {section.max_slides} を超過 (actual={count})",
+        )
+        return round(min(1.0, section.max_slides / count), 3), [mismatch]
+
+    return 1.0, []
+
+
+def _capacity_mismatch(
+    template: ChapterTemplate, total_main_pages: int
+) -> DraftTemplateMismatch | None:
+    if template.max_main_pages is None or total_main_pages <= template.max_main_pages:
+        return None
+    severity = "blocker" if template.appendix_policy == "block" else "warn"
+    return DraftTemplateMismatch(
+        section_id="__capacity__",
+        issue="capacity",
+        severity=severity,
+        detail=f"許容枚数 {template.max_main_pages} を超過 (actual={total_main_pages})",
+    )
+
+
+def _calculate_match_score(required_total: int, matched_required: int) -> float:
+    if not required_total:
+        return 1.0
+    return round(max(0.0, min(1.0, matched_required / required_total)), 3)
+
+
+def _parse_slide_summary(item: object) -> tuple[str, DraftAnalyzerSummary] | None:
+    if not isinstance(item, dict):
+        return None
+
+    slide_uid = str(item.get("slide_uid", "")).strip()
+    if not slide_uid:
+        return None
+
+    severity_counts = item.get("severity_counts") or {}
+    high = int(severity_counts.get("high", 0) or 0)
+    medium = int(severity_counts.get("medium", 0) or 0)
+    low = int(severity_counts.get("low", 0) or 0)
+
+    layout_consistency = _normalize_layout_consistency(item.get("layout_consistency"))
+    blocking_tags = _normalize_blocking_tags(item.get("blocking_tags"))
+
+    analyzer_summary = DraftAnalyzerSummary(
+        severity_high=high,
+        severity_medium=medium,
+        severity_low=low,
+        layout_consistency=layout_consistency,
+        blocking_tags=blocking_tags,
+    )
+    return slide_uid, analyzer_summary
+
+
+def _normalize_layout_consistency(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.lower()
+    if normalized in {"ok", "warn", "error"}:
+        return normalized
+    return None
+
+
+def _normalize_blocking_tags(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(str(tag) for tag in value if str(tag).strip())

--- a/tests/draft_intel/test_draft_intel_refactor.py
+++ b/tests/draft_intel/test_draft_intel_refactor.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pptx_generator.draft_intel import (
+    ChapterTemplate,
+    ChapterTemplateSection,
+    evaluate_chapter_template,
+    load_analysis_summary,
+    load_chapter_template,
+)
+
+
+def test_evaluate_chapter_template_reports_optional_excess_and_capacity() -> None:
+    template = ChapterTemplate(
+        template_id="tpl",
+        name="tpl",
+        structure_pattern="custom",
+        required_sections=(ChapterTemplateSection("intro", min_slides=1, max_slides=2),),
+        optional_sections=(ChapterTemplateSection("appendix", max_slides=1),),
+        max_main_pages=2,
+        appendix_policy="block",
+        tags=(),
+    )
+
+    result = evaluate_chapter_template(
+        template=template,
+        section_counts={"intro": 2, "appendix": 2},
+        total_main_pages=3,
+    )
+
+    assert result.match_score == 1.0
+    assert result.section_scores["intro"] == 1.0
+    assert result.section_scores["appendix"] == 0.5
+    issues = {(m.section_id, m.issue, m.severity) for m in result.mismatches}
+    assert ("appendix", "excess", "warn") in issues
+    assert ("__capacity__", "capacity", "blocker") in issues
+
+
+def test_evaluate_chapter_template_reports_capacity_warn() -> None:
+    template = ChapterTemplate(
+        template_id="tpl",
+        name="tpl",
+        structure_pattern="custom",
+        required_sections=(),
+        optional_sections=(),
+        max_main_pages=1,
+        appendix_policy="overflow",
+        tags=(),
+    )
+
+    result = evaluate_chapter_template(
+        template=template,
+        section_counts={},
+        total_main_pages=2,
+    )
+
+    assert result.match_score == 1.0
+    assert [(m.section_id, m.issue, m.severity) for m in result.mismatches] == [
+        ("__capacity__", "capacity", "warn")
+    ]
+
+
+def test_evaluate_chapter_template_marks_required_missing() -> None:
+    template = ChapterTemplate(
+        template_id="tpl",
+        name="tpl",
+        structure_pattern="custom",
+        required_sections=(ChapterTemplateSection("intro", min_slides=1),),
+        optional_sections=(),
+    )
+
+    result = evaluate_chapter_template(
+        template=template,
+        section_counts={},
+        total_main_pages=0,
+    )
+
+    assert result.match_score == 0.0
+    assert result.section_scores["intro"] == 0.0
+    assert [(m.section_id, m.issue) for m in result.mismatches] == [
+        ("intro", "missing")
+    ]
+
+
+def test_evaluate_chapter_template_marks_required_insufficient() -> None:
+    template = ChapterTemplate(
+        template_id="tpl",
+        name="tpl",
+        structure_pattern="custom",
+        required_sections=(ChapterTemplateSection("intro", min_slides=2),),
+        optional_sections=(),
+    )
+
+    result = evaluate_chapter_template(
+        template=template,
+        section_counts={"intro": 1},
+        total_main_pages=1,
+    )
+
+    assert result.match_score == 0.0
+    assert result.section_scores["intro"] == 0.5
+    assert [(m.section_id, m.issue, m.severity) for m in result.mismatches] == [
+        ("intro", "insufficient", "blocker")
+    ]
+
+
+def test_evaluate_chapter_template_optional_zero_sets_score_zero() -> None:
+    template = ChapterTemplate(
+        template_id="tpl",
+        name="tpl",
+        structure_pattern="custom",
+        required_sections=(),
+        optional_sections=(ChapterTemplateSection("appendix", max_slides=2),),
+    )
+
+    result = evaluate_chapter_template(
+        template=template,
+        section_counts={},
+        total_main_pages=0,
+    )
+
+    assert result.section_scores["appendix"] == 0.0
+    assert result.mismatches == []
+
+
+def test_load_analysis_summary_parses_entries(tmp_path: Path) -> None:
+    payload = {
+        "slides": [
+            {
+                "slide_uid": "s1",
+                "severity_counts": {"high": 1, "medium": 0, "low": 2},
+                "layout_consistency": "OK",
+                "blocking_tags": ["tag1", " "],
+            },
+            {
+                "slide_uid": "s2",
+                "severity_counts": {},
+                "layout_consistency": "unknown",
+                "blocking_tags": "not-a-list",
+            },
+            {},
+        ]
+    }
+    path = tmp_path / "analysis_summary.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    summary = load_analysis_summary(path)
+
+    assert set(summary) == {"s1", "s2"}
+    assert summary["s1"].severity_high == 1
+    assert summary["s1"].severity_low == 2
+    assert summary["s1"].layout_consistency == "ok"
+    assert summary["s1"].blocking_tags == ("tag1",)
+    assert summary["s2"].layout_consistency is None
+    assert summary["s2"].blocking_tags == ()
+
+
+def test_load_analysis_summary_normalizes_non_string_layout_and_blocking_tags(tmp_path: Path) -> None:
+    payload = {
+        "slides": [
+            {
+                "slide_uid": "s1",
+                "severity_counts": {},
+                "layout_consistency": 123,
+                "blocking_tags": None,
+            }
+        ]
+    }
+    path = tmp_path / "analysis_summary.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    summary = load_analysis_summary(path)
+
+    assert summary["s1"].layout_consistency is None
+    assert summary["s1"].blocking_tags == ()
+
+
+def test_load_chapter_template_parses_constraints(tmp_path: Path) -> None:
+    base_dir = tmp_path / "templates"
+    base_dir.mkdir()
+    template_path = base_dir / "custom.json"
+    template_path.write_text(
+        json.dumps(
+            {
+                "template_id": "custom",
+                "name": "Custom Template",
+                "structure_pattern": "custom",
+                "required_sections": [{"id": "intro", "min_slides": 1, "max_slides": 2}],
+                "optional_sections": [{"id": "appendix", "max_slides": 1}],
+                "constraints": {
+                    "max_main_pages": 10,
+                    "appendix_policy": "block",
+                    "tags": ["alpha", ""],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    template = load_chapter_template(base_dir, "custom")
+
+    assert template is not None
+    assert template.max_main_pages == 10
+    assert template.appendix_policy == "block"
+    assert template.tags == ("alpha",)
+    assert template.required_sections[0].section_id == "intro"


### PR DESCRIPTION
## 概要
- draft_intel の条件分岐をヘルパー化して認知的複雑度を下げ、容量超過や必須/任意セクションの評価、analysis summary 正規化を安全に扱えるようにしました。
- Issue #479 で指摘された分岐漏れ・例外経路をテストで可視化し、主要パスを網羅しました。

## 関連リンク
- Issue Close: #479
- ToDo: なし（今回作成不要の指示に従う）
- ノート／設計資料: なし

## 変更内容
- テンプレート制約・セクション評価・容量超過判定・分析サマリ正規化を小さなヘルパーに分割。
- 必須不足・任意超過・容量超過・非文字列/非リスト入力などの経路をカバーする単体テストを追加。

## ユーザー影響
- 外部インターフェースは変更なし。ドラフト評価ロジックの保守性向上のみ。
- 確認方法: `uv run --extra dev pytest --cov=src/pptx_generator --cov=tests --cov-report=xml` で主要パスが通ること、`uv tool run diff-cover coverage.xml --compare-branch origin/main` で差分カバレッジ 80%以上であることを確認済み。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest --cov=src/pptx_generator --cov=tests --cov-report=xml`
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: なし
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した（今回 ToDo 作成不要の指示に従うため対象なし）
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている（今回変更なし）
- [x] Issue 自動クローズ用に `Close #479` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した（未実施）
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した（影響なしのため更新不要）
- [x] 生成物（PDF など）がある場合は添付または参照先を明記した（該当なし）
- [x] PR 本文中の `Close #<番号>` や `docs/todo/…` などのプレースホルダをすべて実際の値に置き換えた