### PR TITLE
fix: RM-094 registry locking and backup hardening

### DIFF
--- a/src/pptx_generator/api/routes.py
+++ b/src/pptx_generator/api/routes.py
@@ -6,10 +6,23 @@ import json
 import logging
 import os
 import re
+import tempfile
+import threading
 import time
 import uuid
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterable, Optional
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None
+
+try:
+    import msvcrt
+except ImportError:  # pragma: no cover - non-Windows
+    msvcrt = None
 
 from flask import Blueprint, abort, g, jsonify, request, send_file
 
@@ -438,6 +451,72 @@ def _registry_path(tx_root: Path) -> Path:
     return tx_root / "registry.json"
 
 
+def _registry_lock_path(tx_root: Path) -> Path:
+    return tx_root / ".registry.lock"
+
+
+def _registry_backup_path(tx_root: Path) -> Path:
+    return tx_root / "registry.json.bak"
+
+
+class RegistryCorruptedError(RuntimeError):
+    """既存 registry.json が破損している場合の保護用例外。"""
+
+
+class RegistryBackupCorruptedError(RuntimeError):
+    """バックアップも破損している場合の保護用例外。"""
+
+
+_registry_thread_locks: dict[str, threading.Lock] = {}
+_registry_thread_locks_guard = threading.Lock()
+
+
+def _get_registry_thread_lock(tx_root: Path) -> threading.Lock:
+    key = str(tx_root.resolve())
+    with _registry_thread_locks_guard:
+        lock = _registry_thread_locks.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _registry_thread_locks[key] = lock
+        return lock
+
+
+def _acquire_file_lock(tx_root: Path):
+    lock_path = _registry_lock_path(tx_root)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_file = lock_path.open("a+")
+    if fcntl is not None:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+    elif msvcrt is not None:  # pragma: no cover - Windows
+        msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+    return lock_file
+
+
+def _release_file_lock(lock_file):
+    try:
+        if fcntl is not None:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+        elif msvcrt is not None:  # pragma: no cover - Windows
+            lock_file.seek(0)
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+    finally:
+        lock_file.close()
+
+
+@contextmanager
+def _lock_registry(tx_root: Path):
+    thread_lock = _get_registry_thread_lock(tx_root)
+    lock_file = None
+    thread_lock.acquire()
+    try:
+        lock_file = _acquire_file_lock(tx_root)
+        yield
+    finally:
+        if lock_file is not None:
+            _release_file_lock(lock_file)
+        thread_lock.release()
+
+
 def _wrap_job(stage: str, job_id: str, transaction_id: str, func):
     logger = logging.getLogger("pptx_generator.api")
 
@@ -460,27 +539,58 @@ def _load_registry(tx_root: Path) -> Optional[dict]:
         return None
     try:
         return json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
-        return None
+    except json.JSONDecodeError as exc:
+        logger = logging.getLogger("pptx_generator.api")
+        logger.warning("registry decode failed path=%s", path)
+        backup_path = _registry_backup_path(tx_root)
+        if backup_path.exists():
+            try:
+                return json.loads(backup_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError as backup_exc:
+                logger.error("registry backup decode failed path=%s", backup_path)
+                raise RegistryBackupCorruptedError(str(backup_path)) from backup_exc
+        raise RegistryCorruptedError(str(path)) from exc
+
+
+def _atomic_write_json(path: Path, content: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        backup_path = path.parent / f"{path.name}.bak"
+        try:
+            backup_path.write_bytes(path.read_bytes())
+        except OSError:
+            # バックアップが取れなくても本処理は続行する（ログのみ）
+            logging.getLogger("pptx_generator.api").warning("registry backup failed path=%s", backup_path)
+    fd, tmp_name = tempfile.mkstemp(prefix=f"{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
+            json.dump(content, tmp_file, ensure_ascii=False, indent=2)
+            tmp_file.flush()
+            os.fsync(tmp_file.fileno())
+        os.replace(tmp_path, path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
 
 
 def _update_registry(tx_root: Path, stage: str, state) -> None:
-    registry = _load_registry(tx_root) or {}
-    artifacts = {}
-    if isinstance(state.result, dict):
-        artifacts = state.result.get("artifacts") or {}
-    # store relative paths when under tx_root
-    rel_artifacts = {}
-    for key, value in artifacts.items():
-        p = Path(value)
-        try:
-            rel = p.relative_to(tx_root)
-            rel_artifacts[key] = str(rel)
-        except ValueError:
-            rel_artifacts[key] = value
-    registry[stage] = {"job_id": state.request.job_id, "artifacts": rel_artifacts}
     tx_root.mkdir(parents=True, exist_ok=True)
-    _registry_path(tx_root).write_text(json.dumps(registry, ensure_ascii=False, indent=2), encoding="utf-8")
+    with _lock_registry(tx_root):
+        registry = _load_registry(tx_root) or {}
+        artifacts = {}
+        if isinstance(state.result, dict):
+            artifacts = state.result.get("artifacts") or {}
+        # store relative paths when under tx_root
+        rel_artifacts = {}
+        for key, value in artifacts.items():
+            p = Path(value)
+            try:
+                rel = p.relative_to(tx_root)
+                rel_artifacts[key] = str(rel)
+            except ValueError:
+                rel_artifacts[key] = value
+        registry[stage] = {"job_id": state.request.job_id, "artifacts": rel_artifacts}
+        _atomic_write_json(_registry_path(tx_root), registry)
 
 
 def _resolve_stage_artifacts(tx_root: Path, stage: str, keys: list[str], allow_missing: bool = False) -> dict[str, str]:

--- a/tests/api/test_stage_artifacts.py
+++ b/tests/api/test_stage_artifacts.py
@@ -1,12 +1,37 @@
 import json
+import multiprocessing
+import threading
+from pathlib import Path
 
 import pytest
 from werkzeug.exceptions import HTTPException
 
 from pptx_generator.api.flask_app import create_app
-from pptx_generator.api.routes import _ensure_stage_artifacts, _registry_path
+from pptx_generator.api.routes import (
+    _ensure_stage_artifacts,
+    _registry_backup_path,
+    _registry_lock_path,
+    _registry_path,
+    _update_registry,
+)
 from pptx_generator.runtime.job_queue import InProcessJobQueue, JobRequest, JobState, JobStatus
 from datetime import datetime, timezone
+
+
+def _proc_update_registry(tx_root_str: str, stage: str, artifact_rel: str, barrier):
+    from pptx_generator.api.routes import _update_registry
+    from pptx_generator.runtime.job_queue import JobRequest, JobState, JobStatus
+
+    tx_root = Path(tx_root_str)
+    artifact_path = tx_root / artifact_rel
+    request = JobRequest(stage=stage, func=lambda: None, transaction_id="tx-proc", job_id=f"job-{stage}")
+    state = JobState(
+        request=request,
+        status=JobStatus.SUCCEEDED,
+        result={"artifacts": {"pptx_url": str(artifact_path)}},
+    )
+    barrier.wait()
+    _update_registry(tx_root, stage, state)
 
 
 @pytest.fixture
@@ -221,3 +246,105 @@ def test_missing_registry_returns_404(api_app, tmp_path):
     with api_app.app_context(), pytest.raises(HTTPException) as excinfo:
         _ensure_stage_artifacts(queue, tmp_path, "tx-10", "template", ["jobspec_url"])
     assert excinfo.value.response.status_code == 404
+
+
+def test_update_registry_uses_lock_and_preserves_entries(tmp_path):
+    barrier = threading.Barrier(2)
+
+    def run(stage: str, artifact_path: Path):
+        request = JobRequest(stage=stage, func=lambda: None, transaction_id="tx-lock", job_id=f"job-{stage}")
+        state = JobState(
+            request=request,
+            status=JobStatus.SUCCEEDED,
+            result={"artifacts": {"pptx_url": str(artifact_path)}},
+        )
+        barrier.wait()
+        _update_registry(tmp_path, stage, state)
+
+    template_artifact = tmp_path / "template" / "out1.pptx"
+    prepare_artifact = tmp_path / "prepare" / "out2.pptx"
+    for artifact in (template_artifact, prepare_artifact):
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_text("x")
+
+    threads = [
+        threading.Thread(target=run, args=("template", template_artifact)),
+        threading.Thread(target=run, args=("prepare", prepare_artifact)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    registry = json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))
+    assert registry["template"]["artifacts"]["pptx_url"] == str(template_artifact.relative_to(tmp_path))
+    assert registry["prepare"]["artifacts"]["pptx_url"] == str(prepare_artifact.relative_to(tmp_path))
+    assert _registry_lock_path(tmp_path).exists()
+
+
+def test_update_registry_across_processes(tmp_path):
+    import pptx_generator.api.routes as routes_module
+
+    if getattr(routes_module, "fcntl", None) is None and getattr(routes_module, "msvcrt", None) is None:
+        pytest.skip("file locking unavailable in this environment")
+
+    ctx = multiprocessing.get_context("spawn")
+    barrier = ctx.Barrier(2)
+    template_artifact = tmp_path / "template" / "proc1.pptx"
+    prepare_artifact = tmp_path / "prepare" / "proc2.pptx"
+    for artifact in (template_artifact, prepare_artifact):
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_text("x")
+
+    processes = [
+        ctx.Process(
+            target=_proc_update_registry,
+            args=(str(tmp_path), "template", str(template_artifact.relative_to(tmp_path)), barrier),
+        ),
+        ctx.Process(
+            target=_proc_update_registry,
+            args=(str(tmp_path), "prepare", str(prepare_artifact.relative_to(tmp_path)), barrier),
+        ),
+    ]
+    for proc in processes:
+        proc.start()
+    for proc in processes:
+        proc.join(timeout=10)
+        assert proc.exitcode == 0
+
+    registry = json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))
+    assert registry["template"]["artifacts"]["pptx_url"] == str(template_artifact.relative_to(tmp_path))
+    assert registry["prepare"]["artifacts"]["pptx_url"] == str(prepare_artifact.relative_to(tmp_path))
+
+
+def test_corrupted_registry_uses_backup_and_preserves_entries(tmp_path):
+    queue = InProcessJobQueue()
+    tx_id = "tx-backup"
+
+    def make_state(stage: str, artifact_rel: str):
+        request = JobRequest(stage=stage, func=lambda: None, transaction_id=tx_id, job_id=f"job-{stage}")
+        return JobState(
+            request=request,
+            status=JobStatus.SUCCEEDED,
+            result={"artifacts": {"pptx_url": artifact_rel}},
+        )
+
+    # 初回書き込みで registry を生成
+    first_state = make_state("template", "template/base.pptx")
+    _update_registry(tmp_path, "template", first_state)
+
+    # 正常内容をバックアップに保存
+    registry_path = _registry_path(tmp_path)
+    backup_path = _registry_backup_path(tmp_path)
+    backup_path.write_bytes(registry_path.read_bytes())
+
+    # registry を破損させる
+    registry_path.write_text("{invalid_json", encoding="utf-8")
+
+    # backup を元に新しいステージを書き込みできることを確認
+    second_state = make_state("prepare", "prepare/next.pptx")
+    _update_registry(tmp_path, "prepare", second_state)
+
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    assert registry["template"]["artifacts"]["pptx_url"] == "template/base.pptx"
+    assert registry["prepare"]["artifacts"]["pptx_url"] == "prepare/next.pptx"


### PR DESCRIPTION
## 概要
- registry.json の更新競合と破損時のデータ喪失を防ぐため、tx_root 単位のロックとバックアップ復旧を導入しました。
- 破損ファイルからの復旧とプロセス間並行更新のテストを追加し、レース耐性を高めました。

## 関連リンク
- Issue Close: #501
- ToDo: なし（今回のタスクは ToDo 作成不要と指示あり）
- ノート／設計資料: なし

## 変更内容
- registry 更新にスレッド＋ファイルロックを追加し、書き込みを原子的置換に統一。
- registry decode 失敗時にバックアップを自動読込し、バックアップも破損していれば例外を送出。
- スレッド／プロセス並行でのレース、および破損ファイルからの復旧を確認するテストを追加。

## ユーザー影響
- 同一トランザクションで並行完了したジョブでも registry.json が破損・上書き消失しにくくなります。
- 影響確認: 並行ジョブ完了後に registry.json の各 stage.artifacts が保持されていることを確認。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest`
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: なし
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した（ToDo なし）
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている（今回は更新なし）
- [x] Issue 自動クローズ用に `Close #<番号>` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した（今回対象なし）
- [ ] 生成物（PDF など）がある場合は添付または参照先を明記した（対象なし）
- [x] PR 本文中の `Close #<番号>` や `docs/todo/…` などのプレースホルダをすべて実際の値に置き換えた