### PR TITLE
fix: RM-491 template-id-hooks

### DIFF
--- a/src/pptx_generator/cli_commands/hook_runner.py
+++ b/src/pptx_generator/cli_commands/hook_runner.py
@@ -16,6 +16,7 @@ def load_stage_hooks(spec_path: Path) -> tuple[ExternalHookManager | None, str |
     """jobspec から template_id を抽出し、対応する HookManager を返す。"""
 
     template_id = extract_template_id_from_json_file(spec_path)
+
     hook_manager = load_hooks_for_template_id(template_id) if template_id else None
     return hook_manager, template_id
 

--- a/src/pptx_generator/cli_hooks/__init__.py
+++ b/src/pptx_generator/cli_hooks/__init__.py
@@ -15,6 +15,7 @@ from .manager import (
 from .template_id import (
     derive_template_id_from_template_path,
     extract_template_id_from_json_file,
+    TemplateIdExtractionError,
 )
 from .slides import (
     build_slide_key,
@@ -29,6 +30,7 @@ __all__ = [
     "SlideContext",
     "derive_template_id_from_template_path",
     "extract_template_id_from_json_file",
+    "TemplateIdExtractionError",
     "STAGE_TEMPLATE",
     "STAGE_PREPARE",
     "STAGE_COMPOSE",

--- a/src/pptx_generator/cli_hooks/template_id.py
+++ b/src/pptx_generator/cli_hooks/template_id.py
@@ -6,11 +6,23 @@ import json
 import re
 import unicodedata
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+class TemplateIdExtractionError(RuntimeError):
+    """template_id 抽出に失敗した際の例外。"""
+
+    def __init__(self, *, path: Path, reason: str) -> None:
+        super().__init__(reason)
+        self.path = path
+        self.reason = reason
+
+    def format_user_message(self) -> str:
+        return f"template_id の抽出に失敗しました: {self.reason} (path={self.path})"
 
 
 def derive_template_id_from_template_path(path: Path) -> str:
@@ -23,56 +35,96 @@ def derive_template_id_from_template_path(path: Path) -> str:
     return stem or "template"
 
 
-def extract_template_id_from_json_file(path: Path) -> str | None:
+def extract_template_id_from_json_file(
+    path: Path, *, strict: bool = False, require_id: bool = False
+) -> str | None:
     """JSON ファイル内から template_id を抽出する。
 
     jobspec / generate_ready / template_spec など複数の候補フィールドを走査する。
+
+    strict=True の場合はファイル欠落や JSON 不正時に TemplateIdExtractionError を送出し、
+    呼び出し元で一貫したエラー処理を行えるようにする。
+    require_id=True を指定すると template_id が存在しない場合にも TemplateIdExtractionError を送出する。
     """
     try:
-        text = path.read_text(encoding="utf-8")
-        data: Any = json.loads(text)
-    except FileNotFoundError:
-        logger.debug("template_id 抽出対象のファイルが見つかりません: %s", path)
-        return None
-    except json.JSONDecodeError as exc:
-        logger.debug("template_id 抽出対象の JSON 読み込みに失敗: %s (%s)", path, exc)
+        payload = _load_json(path)
+    except TemplateIdExtractionError:
+        if strict:
+            raise
+        logger.debug("template_id 抽出対象のファイルを読み込めません: %s", path)
         return None
 
-    return _search_template_id(data)
+    template_id = _search_template_id(payload)
+    if template_id:
+        return template_id
+
+    if require_id:
+        if strict:
+            raise TemplateIdExtractionError(path=path, reason="template_id が見つかりません")
+        return None
+    return None
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise TemplateIdExtractionError(path=path, reason="ファイルが存在しません") from exc
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise TemplateIdExtractionError(path=path, reason=f"JSON が不正です: {exc}") from exc
 
 
 def _search_template_id(payload: Any) -> str | None:
-    """辞書・リスト内を深さ優先で走査して template_id を探す。"""
-    if isinstance(payload, dict):
-        # 直接的なフィールド名を優先
-        direct = payload.get("template_id")
-        if isinstance(direct, str) and direct.strip():
-            return direct.strip()
+    """辞書・リスト内を深さ優先で走査して template_id を探す（優先順位: top > meta > template_style > その他）。"""
 
-        # meta 下に格納されているケース
-        meta = payload.get("meta")
-        if isinstance(meta, dict):
-            direct = meta.get("template_id")
-            if isinstance(direct, str) and direct.strip():
-                return direct.strip()
+    stack = [payload]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, dict):
+            direct = _extract_direct_template_id(current)
+            if direct:
+                return direct
 
-        # blueprint や template_style などに含まれているケース
-        template_style = payload.get("template_style")
-        if isinstance(template_style, dict):
-            direct = template_style.get("template_id")
-            if isinstance(direct, str) and direct.strip():
-                return direct.strip()
+            meta = current.get("meta")
+            meta_direct = _extract_direct_template_id(meta) if isinstance(meta, dict) else None
+            if meta_direct:
+                return meta_direct
 
-        # その他のネストを探索
-        for value in payload.values():
-            result = _search_template_id(value)
-            if result:
-                return result
+            template_style = current.get("template_style")
+            style_direct = (
+                _extract_direct_template_id(template_style) if isinstance(template_style, dict) else None
+            )
+            if style_direct:
+                return style_direct
 
-    elif isinstance(payload, list):
-        for item in payload:
-            result = _search_template_id(item)
-            if result:
-                return result
+            if isinstance(meta, dict):
+                stack.append(meta)
+            if isinstance(template_style, dict):
+                stack.append(template_style)
+
+            for value in current.values():
+                if value is meta or value is template_style:
+                    continue
+                stack.append(value)
+        elif isinstance(current, list):
+            stack.extend(current)
 
     return None
+
+
+def _extract_direct_template_id(mapping: Mapping[str, Any] | None) -> str | None:
+    if not mapping:
+        return None
+
+    return _normalize_template_id(mapping.get("template_id"))
+
+
+def _normalize_template_id(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+
+    normalized = value.strip()
+    return normalized or None

--- a/tests/cli/test_cli_hook_invocations.py
+++ b/tests/cli/test_cli_hook_invocations.py
@@ -113,6 +113,59 @@ def test_prepare_invokes_slide_hooks_with_fallback(monkeypatch, tmp_path: Path) 
     assert post_call["continue_default_filter"] is True
 
 
+def test_prepare_missing_template_id_does_not_call_hooks(monkeypatch, tmp_path: Path) -> None:
+    called = {}
+
+    def fake_run_prepare_command(config, dump_json):  # noqa: ANN001
+        called["ran"] = True
+        return type(
+            "Result",
+            (),
+            {
+                "messages": [],
+                "cards_path": tmp_path / "cards.json",
+                "log_path": tmp_path / "log.json",
+                "ai_log_path": tmp_path / "ai_log.json",
+                "meta_path": tmp_path / "meta.json",
+                "story_outline_path": tmp_path / "story.json",
+                "audit_path": tmp_path / "audit.json",
+            },
+        )()
+
+    monkeypatch.setattr("pptx_generator.cli_commands.prepare.run_prepare_command", fake_run_prepare_command)
+    monkeypatch.setattr("pptx_generator.cli_commands.prepare.run_job_sync", lambda **kwargs: kwargs["func"]())
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.prepare.load_hooks_for_template_id",
+        lambda tpl: (_ for _ in ()).throw(AssertionError("should not load hooks when template_id missing")),
+    )
+
+    command = create_prepare_command(
+        default_output_dir=tmp_path / ".pptx/prepare",
+        default_jobspec_path=tmp_path / "jobspec.json",
+        prompts_dirname=tmp_path / ".pptx/template/prompts",
+        slide_inputs_filename=Path("slide_inputs.md"),
+    )
+
+    jobspec = tmp_path / "jobspec.json"
+    jobspec.write_text("{}", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        command,
+        [
+            "--mode",
+            "static",
+            "--jobspec",
+            str(jobspec),
+            "--output",
+            str(tmp_path / ".pptx/prepare"),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert called.get("ran") is True
+
+
 def test_mapping_invokes_slide_hooks_with_fallback(monkeypatch, tmp_path: Path) -> None:
     hook_manager = DummyHookManager()
     monkeypatch.setattr(
@@ -253,6 +306,53 @@ def test_gen_invokes_slide_hooks_with_fallback(monkeypatch, tmp_path: Path) -> N
     assert pre_call["continue_default_filter"] is False
     assert post_call["allow_fallback_context"] is True
     assert post_call["continue_default_filter"] is True
+
+
+def test_gen_missing_template_id_does_not_call_hooks(monkeypatch, tmp_path: Path) -> None:
+    class DummyContext:
+        def __init__(self) -> None:
+            self.artifacts = {"pptx_path": tmp_path / "out" / "out.pptx"}
+
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.run_generate_command",
+        lambda config: type("R", (), {"context": DummyContext(), "audit_path": tmp_path / "audit.json"})(),
+    )
+    monkeypatch.setattr("pptx_generator.cli_commands.gen.run_job_sync", lambda **kwargs: kwargs["func"]())
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.load_hooks_for_template_id",
+        lambda tpl: (_ for _ in ()).throw(AssertionError("should not load hooks when template_id missing")),
+    )
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.slide_contexts_from_generate_ready",
+        lambda *args, **kwargs: [],
+    )
+    cmd = create_gen_command(
+        default_output_dir=tmp_path / "out",
+        default_pptx_name="out.pptx",
+        default_rules_path=_touch(tmp_path / "pipeline_rules.json"),
+        default_pdf_output="out.pdf",
+        default_pdf_timeout=10,
+        default_pdf_retries=1,
+    )
+
+    generate_ready = _touch(tmp_path / "generate_ready.json")
+    generate_ready.write_text("{}", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        cmd,
+        [
+            str(generate_ready),
+            "--output",
+            str(tmp_path / "out"),
+            "--pptx-name",
+            "out.pptx",
+            "--rules",
+            str(tmp_path / "pipeline_rules.json"),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
 
 
 def test_template_invokes_slide_hooks_with_fallback(monkeypatch, tmp_path: Path) -> None:

--- a/tests/cli/test_hook_runner.py
+++ b/tests/cli/test_hook_runner.py
@@ -84,6 +84,16 @@ def test_load_stage_hooks_propagates_exceptions(monkeypatch, tmp_path) -> None:
         load_stage_hooks(spec_path)
 
 
+def test_load_stage_hooks_returns_none_for_missing_template(monkeypatch, tmp_path) -> None:
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text("{}", encoding="utf-8")
+
+    hook_manager, template_id = load_stage_hooks(spec_path)
+
+    assert hook_manager is None
+    assert template_id is None
+
+
 def test_run_post_stage_slide_hooks_propates_loader_error(tmp_path) -> None:
     class DummyHM:
         def run_slide_hooks(self, *_, **__):  # noqa: ANN001, ARG002

--- a/tests/cli/test_template_id.py
+++ b/tests/cli/test_template_id.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pptx_generator.cli_hooks.template_id import (
+    TemplateIdExtractionError,
+    extract_template_id_from_json_file,
+)
+
+
+def test_extract_template_id_from_json_file_finds_nested_meta(tmp_path: Path) -> None:
+    payload = {"meta": {"template_id": "demo_meta"}}
+    target = tmp_path / "spec.json"
+    target.write_text('{"meta":{"template_id":"demo_meta"}}', encoding="utf-8")
+
+    template_id = extract_template_id_from_json_file(target, strict=True)
+
+    assert template_id == "demo_meta"
+
+
+def test_extract_template_id_from_json_file_top_level(tmp_path: Path) -> None:
+    target = tmp_path / "spec.json"
+    target.write_text('{"template_id":"top_level","meta":{"template_id":"meta_tpl"}}', encoding="utf-8")
+
+    template_id = extract_template_id_from_json_file(target, strict=True)
+
+    assert template_id == "top_level"
+
+
+def test_extract_template_id_from_json_file_finds_template_style(tmp_path: Path) -> None:
+    target = tmp_path / "spec.json"
+    target.write_text('{"template_style":{"template_id":"style_tpl"}}', encoding="utf-8")
+
+    template_id = extract_template_id_from_json_file(target, strict=True)
+
+    assert template_id == "style_tpl"
+
+
+def test_extract_template_id_from_json_file_missing_raises_when_strict(tmp_path: Path) -> None:
+    target = tmp_path / "spec.json"
+    target.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(TemplateIdExtractionError):
+        extract_template_id_from_json_file(target, strict=True, require_id=True)
+
+
+def test_extract_template_id_prefers_top_level_over_meta_or_style(tmp_path: Path) -> None:
+    target = tmp_path / "spec.json"
+    target.write_text(
+        '{"template_id":"top","meta":{"template_id":"meta_tpl"},"template_style":{"template_id":"style_tpl"}}',
+        encoding="utf-8",
+    )
+
+    template_id = extract_template_id_from_json_file(target, strict=True)
+
+    assert template_id == "top"
+
+
+def test_extract_template_id_from_json_file_invalid_json_strict(tmp_path: Path) -> None:
+    target = tmp_path / "spec.json"
+    target.write_text("{invalid", encoding="utf-8")
+
+    with pytest.raises(TemplateIdExtractionError):
+        extract_template_id_from_json_file(target, strict=True)
+
+
+def test_extract_template_id_from_json_file_missing_file_non_strict_returns_none(tmp_path: Path) -> None:
+    target = tmp_path / "missing.json"
+
+    assert extract_template_id_from_json_file(target, strict=False) is None
+
+
+def test_template_id_extraction_error_format(tmp_path: Path) -> None:
+    exc = TemplateIdExtractionError(path=tmp_path / "missing.json", reason="fail")
+
+    assert "missing.json" in exc.format_user_message()
+    assert "fail" in exc.format_user_message()


### PR DESCRIPTION
## 概要
- template_id 抽出ロジックの認知的複雑度を下げ、トップレベル優先の探索順を明示してエラー挙動を整理。
- template_id 欠落時のフック呼び出しを避けつつ従来の非強制挙動を維持。
- 欠落/不正 JSON/優先順位/フック未実行ケースを追加テストで担保。

## 関連リンク
- Issue Close: Close #491
- ToDo: なし（ユーザー指示により未作成）
- ノート／設計資料: なし

## 変更内容
- template_id 抽出をスタック走査＋優先順位明示化にリファクタし、不要になったエラーハンドラを削除。
- prepare/gen/hook_runner で新 API を利用しつつ従来の非強制挙動を維持。
- template_id 優先順位・欠落時挙動・フック未実行確認のユニット/CLI テストを追加。

## ユーザー影響
- template_id が欠落した静的実行時もフックが呼ばれず従来どおり既定処理が継続する。
- template_id が複数ある場合、トップレベルが優先されることが明確になり予期しない ID 選択を防止。
- 確認方法: 上記ケースで CLI がエラー終了しないこと、フックが呼ばれないことをテストが担保。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest`
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: なし
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [x] 該当 ToDo のチェックボックスとメモを最新化した（ToDo なし）
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている（今回対象外）
- [x] Issue 自動クローズ用に `Close #491` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した（必要に応じて実施）
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した（影響なし）
- [ ] 生成物（PDF など）がある場合は添付または参照先を明記した（該当なし）
- [x] PR 本文中の `Close #491` や `docs/todo/…` などのプレースホルダをすべて実際の値に置き換えた
