### PR TITLE
fix: RM-000 compose hook flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ src/pptx_generator.egg-info/
 
 # Logs and caches
 *.log
+logs/
 .cache/
 .coverage
 coverage.xml

--- a/src/pptx_generator/cli_commands/compose.py
+++ b/src/pptx_generator/cli_commands/compose.py
@@ -24,6 +24,123 @@ from pptx_generator.cli_commands.hook_runner import (
 from .utils import draft_common_options, handle_command_error
 
 
+def _build_stage_env(
+    *,
+    spec_path: Path,
+    output_dir: Path,
+    draft_output: Path,
+    target_length: int | None,
+    structure_pattern: str | None,
+    appendix_limit: int,
+    analysis_summary_path: Path | None,
+    show_layout_reasons: bool,
+    rules: Path,
+    prepare_cards: Path,
+    template_id: str | None,
+) -> dict[str, str]:
+    chapter_templates_dir: Path | None = None
+    chapter_template: str | None = structure_pattern
+    stage_env = {
+        "PPTX_STAGE": STAGE_COMPOSE,
+        "PPTX_SPEC_PATH": str(spec_path.resolve()),
+        "PPTX_OUTPUT_DIR": str(output_dir.resolve()),
+        "PPTX_DRAFT_OUTPUT": str(draft_output.resolve()),
+        "PPTX_TARGET_LENGTH": str(target_length) if target_length is not None else "",
+        "PPTX_STRUCTURE_PATTERN": structure_pattern or "",
+        "PPTX_APPENDIX_LIMIT": str(appendix_limit),
+        "PPTX_ANALYSIS_SUMMARY_PATH": str(analysis_summary_path.resolve())
+        if analysis_summary_path
+        else "",
+        "PPTX_SHOW_LAYOUT_REASONS": "1" if show_layout_reasons else "0",
+        "PPTX_RULES_PATH": str(rules.resolve()),
+        "PPTX_PREPARE_CARDS_PATH": str(prepare_cards.resolve()),
+    }
+    stage_env["PPTX_CHAPTER_TEMPLATES_DIR"] = (
+        str(chapter_templates_dir.resolve()) if chapter_templates_dir else ""
+    )
+    stage_env["PPTX_CHAPTER_TEMPLATE"] = chapter_template or ""
+    if template_id:
+        stage_env["PPTX_TEMPLATE_ID"] = template_id
+    return stage_env
+
+
+def _run_stage_and_slide_hooks(
+    *,
+    hook_manager,
+    template_id: str | None,
+    stage_env: dict[str, str],
+    prepare_cards: Path,
+):
+    if run_stage_hook(
+        STAGE_COMPOSE,
+        hook_manager=hook_manager,
+        template_id=template_id,
+        stage_env=stage_env,
+    ):
+        return None
+
+    contexts = slide_contexts_from_generate_ready(prepare_cards)
+    if run_slide_hooks(
+        STAGE_COMPOSE,
+        hook_manager=hook_manager,
+        stage_env=stage_env,
+        slides=contexts,
+        continue_default_filter=False,
+    ):
+        return None
+    return contexts
+
+
+def _build_compose_config(
+    *,
+    spec_path: Path,
+    draft_output: Path,
+    target_length: int | None,
+    structure_pattern: str | None,
+    appendix_limit: int,
+    analysis_summary_path: Path | None,
+    show_layout_reasons: bool,
+    output_dir: Path,
+    rules: Path,
+    prepare_cards: Path,
+    default_draft_filename: str,
+    default_approved_filename: str,
+    default_draft_log_filename: str,
+    default_draft_meta_filename: str,
+    default_generate_ready_filename: str,
+    default_generate_ready_meta_filename: str,
+) -> ComposeCommandConfig:
+    return ComposeCommandConfig(
+        spec_path=spec_path,
+        draft_output=draft_output,
+        target_length=target_length,
+        structure_pattern=structure_pattern,
+        appendix_limit=appendix_limit,
+        analysis_summary_path=analysis_summary_path,
+        show_layout_reasons=show_layout_reasons,
+        output_dir=output_dir,
+        rules_path=rules,
+        prepare_cards=prepare_cards,
+        draft_filename=default_draft_filename,
+        approved_filename=default_approved_filename,
+        log_filename=default_draft_log_filename,
+        meta_filename=default_draft_meta_filename,
+        generate_ready_filename=default_generate_ready_filename,
+        generate_ready_meta_filename=default_generate_ready_meta_filename,
+    )
+
+
+def _execute_compose(config: ComposeCommandConfig) -> None:
+    try:
+        run_job_sync(
+            stage="compose",
+            func=lambda: run_compose_command(config),
+        )
+    except ComposeCommandError as exc:
+        handle_command_error(exc, default_message="エラーが発生しました")
+        raise click.exceptions.Exit(code=exc.exit_code) from exc
+
+
 def create_compose_command(
     *,
     default_appendix_limit: int,
@@ -78,48 +195,30 @@ def create_compose_command(
 
         draft_output = output_dir / "draft"
         hook_manager, template_id = load_stage_hooks(spec_path)
-        chapter_templates_dir: Path | None = None
-        chapter_template: str | None = structure_pattern
-        stage_env = {
-            "PPTX_STAGE": STAGE_COMPOSE,
-            "PPTX_SPEC_PATH": str(spec_path.resolve()),
-            "PPTX_OUTPUT_DIR": str(output_dir.resolve()),
-            "PPTX_DRAFT_OUTPUT": str(draft_output.resolve()),
-            "PPTX_TARGET_LENGTH": str(target_length) if target_length is not None else "",
-            "PPTX_STRUCTURE_PATTERN": structure_pattern or "",
-            "PPTX_APPENDIX_LIMIT": str(appendix_limit),
-            "PPTX_ANALYSIS_SUMMARY_PATH": str(analysis_summary_path.resolve())
-            if analysis_summary_path
-            else "",
-            "PPTX_SHOW_LAYOUT_REASONS": "1" if show_layout_reasons else "0",
-            "PPTX_RULES_PATH": str(rules.resolve()),
-            "PPTX_PREPARE_CARDS_PATH": str(prepare_cards.resolve()),
-        }
-        stage_env["PPTX_CHAPTER_TEMPLATES_DIR"] = (
-            str(chapter_templates_dir.resolve()) if chapter_templates_dir else ""
+        stage_env = _build_stage_env(
+            spec_path=spec_path,
+            output_dir=output_dir,
+            draft_output=draft_output,
+            target_length=target_length,
+            structure_pattern=structure_pattern,
+            appendix_limit=appendix_limit,
+            analysis_summary_path=analysis_summary_path,
+            show_layout_reasons=show_layout_reasons,
+            rules=rules,
+            prepare_cards=prepare_cards,
+            template_id=template_id,
         )
-        stage_env["PPTX_CHAPTER_TEMPLATE"] = chapter_template or ""
-        if template_id:
-            stage_env["PPTX_TEMPLATE_ID"] = template_id
-        if run_stage_hook(
-            STAGE_COMPOSE,
+
+        contexts = _run_stage_and_slide_hooks(
             hook_manager=hook_manager,
             template_id=template_id,
             stage_env=stage_env,
-        ):
+            prepare_cards=prepare_cards,
+        )
+        if contexts is None:
             return
 
-        contexts = slide_contexts_from_generate_ready(prepare_cards)
-        if run_slide_hooks(
-            STAGE_COMPOSE,
-            hook_manager=hook_manager,
-            stage_env=stage_env,
-            slides=contexts,
-            continue_default_filter=False,
-        ):
-            return
-
-        config = ComposeCommandConfig(
+        config = _build_compose_config(
             spec_path=spec_path,
             draft_output=draft_output,
             target_length=target_length,
@@ -128,23 +227,17 @@ def create_compose_command(
             analysis_summary_path=analysis_summary_path,
             show_layout_reasons=show_layout_reasons,
             output_dir=output_dir,
-            rules_path=rules,
+            rules=rules,
             prepare_cards=prepare_cards,
-            draft_filename=default_draft_filename,
-            approved_filename=default_approved_filename,
-            log_filename=default_draft_log_filename,
-            meta_filename=default_draft_meta_filename,
-            generate_ready_filename=default_generate_ready_filename,
-            generate_ready_meta_filename=default_generate_ready_meta_filename,
+            default_draft_filename=default_draft_filename,
+            default_approved_filename=default_approved_filename,
+            default_draft_log_filename=default_draft_log_filename,
+            default_draft_meta_filename=default_draft_meta_filename,
+            default_generate_ready_filename=default_generate_ready_filename,
+            default_generate_ready_meta_filename=default_generate_ready_meta_filename,
         )
-        try:
-            run_job_sync(
-                stage="compose",
-                func=lambda: run_compose_command(config),
-            )
-        except ComposeCommandError as exc:
-            handle_command_error(exc, default_message="エラーが発生しました")
-            raise click.exceptions.Exit(code=exc.exit_code) from exc
+
+        _execute_compose(config)
 
         run_post_stage_slide_hooks(
             STAGE_COMPOSE,

--- a/tests/cli/test_cli_hook_invocations.py
+++ b/tests/cli/test_cli_hook_invocations.py
@@ -260,6 +260,298 @@ def test_compose_invokes_slide_hooks_with_fallback(monkeypatch, tmp_path: Path) 
     assert post_call["continue_default_filter"] is True
 
 
+def test_compose_stage_hook_can_short_circuit(monkeypatch, tmp_path: Path) -> None:
+    called: dict[str, object] = {}
+
+    def short_circuit_stage_hook(stage, *, hook_manager, template_id, stage_env):  # noqa: ANN001
+        called["stage_env"] = dict(stage_env)
+        return True
+
+    monkeypatch.setattr("pptx_generator.cli_commands.compose.run_stage_hook", short_circuit_stage_hook)
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.compose.load_stage_hooks",
+        lambda path: ("dummy_manager", "demo_tpl"),
+    )
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.compose.slide_contexts_from_generate_ready",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("slide contexts should not run")),
+    )
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.compose.run_compose_command",
+        lambda config: (_ for _ in ()).throw(AssertionError("compose should not run when stage hook short-circuits")),
+    )
+
+    cmd = create_compose_command(
+        default_appendix_limit=0,
+        default_output_dir=tmp_path / "out",
+        default_rules_path=_touch(tmp_path / "pipeline_rules.json"),
+        default_prepare_cards_path=_touch(tmp_path / "prepare_card.json"),
+        default_draft_filename="draft.json",
+        default_approved_filename="approved.json",
+        default_draft_log_filename="draft_log.json",
+        default_draft_meta_filename="draft_meta.json",
+        default_generate_ready_filename="generate_ready.json",
+        default_generate_ready_meta_filename="generate_ready_meta.json",
+    )
+
+    spec = _touch(tmp_path / "spec.json")
+    result = CliRunner().invoke(
+        cmd,
+        [
+            str(spec),
+            "--output",
+            str(tmp_path / "out"),
+            "--rules",
+            str(tmp_path / "pipeline_rules.json"),
+            "--prepare-cards",
+            str(tmp_path / "prepare_card.json"),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    stage_env = called.get("stage_env")
+    assert isinstance(stage_env, dict)
+    assert stage_env["PPTX_STAGE"] == "compose"
+    assert "PPTX_SPEC_PATH" in stage_env
+
+
+def test_compose_slide_hook_can_short_circuit(monkeypatch, tmp_path: Path) -> None:
+    called: dict[str, object] = {"slides": None}
+
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.compose.load_stage_hooks",
+        lambda path: ("dummy_manager", "demo_tpl"),
+    )
+
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.compose.run_stage_hook",
+        lambda *args, **kwargs: False,
+    )
+
+    def short_circuit_slide_hook(stage, *, hook_manager, stage_env, slides, continue_default_filter):  # noqa: ANN001
+        called["slides"] = slides
+        return True
+
+    monkeypatch.setattr("pptx_generator.cli_commands.compose.run_slide_hooks", short_circuit_slide_hook)
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.compose.slide_contexts_from_generate_ready",
+        lambda *args, **kwargs: ["ctx"],
+    )
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.compose.run_compose_command",
+        lambda config: (_ for _ in ()).throw(AssertionError("compose should not run when slide hook short-circuits")),
+    )
+
+    cmd = create_compose_command(
+        default_appendix_limit=0,
+        default_output_dir=tmp_path / "out",
+        default_rules_path=_touch(tmp_path / "pipeline_rules.json"),
+        default_prepare_cards_path=_touch(tmp_path / "prepare_card.json"),
+        default_draft_filename="draft.json",
+        default_approved_filename="approved.json",
+        default_draft_log_filename="draft_log.json",
+        default_draft_meta_filename="draft_meta.json",
+        default_generate_ready_filename="generate_ready.json",
+        default_generate_ready_meta_filename="generate_ready_meta.json",
+    )
+
+    spec = _touch(tmp_path / "spec.json")
+    result = CliRunner().invoke(
+        cmd,
+        [
+            str(spec),
+            "--output",
+            str(tmp_path / "out"),
+            "--rules",
+            str(tmp_path / "pipeline_rules.json"),
+            "--prepare-cards",
+            str(tmp_path / "prepare_card.json"),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert called["slides"] == ["ctx"]
+
+
+def test_compose_runs_when_stage_hook_allows(monkeypatch, tmp_path: Path) -> None:
+    called: dict[str, object] = {"stage": False, "slide": False, "compose": False, "post": False}
+
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.compose.load_stage_hooks",
+        lambda path: ("dummy_manager", "demo_tpl"),
+    )
+
+    def stage_hook(*args, **kwargs):  # noqa: ANN001
+        called["stage"] = kwargs.get("stage_env")
+        return False
+
+    monkeypatch.setattr("pptx_generator.cli_commands.compose.run_stage_hook", stage_hook)
+
+    def slide_hook(*args, **kwargs):  # noqa: ANN001
+        called["slide"] = kwargs.get("slides")
+        return False
+
+    monkeypatch.setattr("pptx_generator.cli_commands.compose.run_slide_hooks", slide_hook)
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.compose.slide_contexts_from_generate_ready",
+        lambda *args, **kwargs: ["ctx1", "ctx2"],
+    )
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.compose.run_compose_command",
+        lambda config: called.update({"compose": True}),
+    )
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.compose.run_post_stage_slide_hooks",
+        lambda *args, **kwargs: called.update({"post": True}),
+    )
+
+    cmd = create_compose_command(
+        default_appendix_limit=0,
+        default_output_dir=tmp_path / "out",
+        default_rules_path=_touch(tmp_path / "pipeline_rules.json"),
+        default_prepare_cards_path=_touch(tmp_path / "prepare_card.json"),
+        default_draft_filename="draft.json",
+        default_approved_filename="approved.json",
+        default_draft_log_filename="draft_log.json",
+        default_draft_meta_filename="draft_meta.json",
+        default_generate_ready_filename="generate_ready.json",
+        default_generate_ready_meta_filename="generate_ready_meta.json",
+    )
+
+    spec = _touch(tmp_path / "spec.json")
+    result = CliRunner().invoke(
+        cmd,
+        [
+            str(spec),
+            "--output",
+            str(tmp_path / "out"),
+            "--rules",
+            str(tmp_path / "pipeline_rules.json"),
+            "--prepare-cards",
+            str(tmp_path / "prepare_card.json"),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert called["stage"] is not False
+    assert called["slide"] == ["ctx1", "ctx2"]
+    assert called["compose"] is True
+    assert called["post"] is True
+
+
+def test_compose_stage_env_includes_optional_keys(monkeypatch, tmp_path: Path) -> None:
+    captured_env: dict[str, str] = {}
+
+    def capture_stage_hook(stage, *, hook_manager, template_id, stage_env):  # noqa: ANN001
+        captured_env.update(stage_env)
+        return False
+
+    monkeypatch.setattr("pptx_generator.cli_commands.compose.run_stage_hook", capture_stage_hook)
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.compose.load_stage_hooks",
+        lambda path: ("dummy_manager", None),
+    )
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.compose.slide_contexts_from_generate_ready",
+        lambda *args, **kwargs: [],
+    )
+    monkeypatch.setattr("pptx_generator.cli_commands.compose.run_slide_hooks", lambda *a, **k: False)
+    monkeypatch.setattr("pptx_generator.cli_commands.compose.run_compose_command", lambda config: None)
+    monkeypatch.setattr("pptx_generator.cli_commands.compose.run_post_stage_slide_hooks", lambda *a, **k: None)
+
+    cmd = create_compose_command(
+        default_appendix_limit=0,
+        default_output_dir=tmp_path / "out",
+        default_rules_path=_touch(tmp_path / "pipeline_rules.json"),
+        default_prepare_cards_path=_touch(tmp_path / "prepare_card.json"),
+        default_draft_filename="draft.json",
+        default_approved_filename="approved.json",
+        default_draft_log_filename="draft_log.json",
+        default_draft_meta_filename="draft_meta.json",
+        default_generate_ready_filename="generate_ready.json",
+        default_generate_ready_meta_filename="generate_ready_meta.json",
+    )
+
+    spec = _touch(tmp_path / "spec.json")
+    result = CliRunner().invoke(
+        cmd,
+        [
+            str(spec),
+            "--output",
+            str(tmp_path / "out"),
+            "--rules",
+            str(tmp_path / "pipeline_rules.json"),
+            "--prepare-cards",
+            str(tmp_path / "prepare_card.json"),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert captured_env["PPTX_TARGET_LENGTH"] == ""
+    assert captured_env["PPTX_STRUCTURE_PATTERN"] == ""
+    assert captured_env["PPTX_ANALYSIS_SUMMARY_PATH"] == ""
+    assert captured_env["PPTX_CHAPTER_TEMPLATE"] == ""
+    assert captured_env["PPTX_CHAPTER_TEMPLATES_DIR"] == ""
+    assert "PPTX_TEMPLATE_ID" not in captured_env or captured_env["PPTX_TEMPLATE_ID"] == ""
+
+
+def test_compose_post_stage_skipped_when_stage_hook_short_circuits(monkeypatch, tmp_path: Path) -> None:
+    called: dict[str, bool] = {"post": False}
+
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.compose.load_stage_hooks",
+        lambda path: ("dummy_manager", "demo_tpl"),
+    )
+    monkeypatch.setattr("pptx_generator.cli_commands.compose.run_stage_hook", lambda *a, **k: True)
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.compose.run_post_stage_slide_hooks",
+        lambda *a, **k: called.update({"post": True}),
+    )
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.compose.slide_contexts_from_generate_ready",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("slide hooks should not run")),
+    )
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.compose.run_compose_command",
+        lambda config: (_ for _ in ()).throw(AssertionError("compose should not run when stage hook short-circuits")),
+    )
+
+    cmd = create_compose_command(
+        default_appendix_limit=0,
+        default_output_dir=tmp_path / "out",
+        default_rules_path=_touch(tmp_path / "pipeline_rules.json"),
+        default_prepare_cards_path=_touch(tmp_path / "prepare_card.json"),
+        default_draft_filename="draft.json",
+        default_approved_filename="approved.json",
+        default_draft_log_filename="draft_log.json",
+        default_draft_meta_filename="draft_meta.json",
+        default_generate_ready_filename="generate_ready.json",
+        default_generate_ready_meta_filename="generate_ready_meta.json",
+    )
+
+    spec = _touch(tmp_path / "spec.json")
+    result = CliRunner().invoke(
+        cmd,
+        [
+            str(spec),
+            "--output",
+            str(tmp_path / "out"),
+            "--rules",
+            str(tmp_path / "pipeline_rules.json"),
+            "--prepare-cards",
+            str(tmp_path / "prepare_card.json"),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert called["post"] is False
+
+
 def test_gen_invokes_slide_hooks_with_fallback(monkeypatch, tmp_path: Path) -> None:
     hook_manager = DummyHookManager()
     monkeypatch.setattr("pptx_generator.cli_commands.gen.load_hooks_for_template_id", lambda tpl: hook_manager)


### PR DESCRIPTION
## 概要
- compose コマンドの認知的複雑度を下げるため、環境変数構築・フック判定・設定生成・ジョブ実行をヘルパー化し、早期リターン経路の挙動を整理しました。
- stage/slide フックの短絡時に後続処理を抑止するパスと、通常継続するパスの両方をテストで固定化しました。

## 関連リンク
- Issue Close: #490
- ToDo: なし（今回タスクで作成不要との指示）
- ノート／設計資料: なし

## 変更内容
- compose CLI エントリの責務分割とフック呼び出しの早期リターン処理を整理。
- stage_env の optional 値やフック短絡時の挙動を検証するユニットテストを追加。
- ローテーションログ用ディレクトリ `logs/` を Git 管理外に追加。

## ユーザー影響
- compose コマンドのフック連携が明示的になり、短絡時に不要処理が走らず安全性が向上します。
- 影響確認: `uv run --extra dev pytest` でフック挙動のテストが通ることを確認。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest`
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: N/A
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した（本タスクは ToDo 作成不要の指示）
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている（本対応の直接変更なし）
- [x] Issue 自動クローズ用に `Close #<番号>` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した
- [ ] 生成物（PDF など）がある場合は添付または参照先を明記した（該当なし）
- [x] PR 本文中の `Close #<番号>` や `docs/todo/…` などのプレースホルダをすべて実際の値に置き換えた