### PR TITLE
fix: RM-000 gen hook refactor

### DIFF
--- a/src/pptx_generator/cli_commands/gen.py
+++ b/src/pptx_generator/cli_commands/gen.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import click
 
@@ -30,6 +30,132 @@ def create_gen_command(
     default_pdf_timeout: int,
     default_pdf_retries: int,
 ) -> click.Command:
+
+    def _build_stage_env(
+        *,
+        generate_ready_path: Path,
+        output_dir: Path,
+        pptx_name: str,
+        rules: Path,
+        export_pdf: bool,
+        pdf_mode: str,
+        pdf_output: str,
+        libreoffice_path: Optional[Path],
+        pdf_timeout: int,
+        pdf_retries: int,
+        polisher_toggle: bool | None,
+        polisher_path: Optional[Path],
+        polisher_rules: Optional[Path],
+        polisher_timeout: Optional[int],
+        polisher_args: tuple[str, ...],
+        polisher_cwd: Optional[Path],
+        emit_structure_snapshot: bool,
+        template_id: str | None,
+    ) -> dict[str, str]:
+        stage_env = {
+            "PPTX_STAGE": STAGE_GEN,
+            "PPTX_GENERATE_READY_PATH": str(generate_ready_path.resolve()),
+            "PPTX_OUTPUT_DIR": str(output_dir.resolve()),
+            "PPTX_PPTX_NAME": pptx_name,
+            "PPTX_RULES_PATH": str(rules.resolve()),
+            "PPTX_EXPORT_PDF": "1" if export_pdf else "0",
+            "PPTX_PDF_MODE": pdf_mode,
+            "PPTX_PDF_OUTPUT": pdf_output,
+            "PPTX_LIBREOFFICE_PATH": str(libreoffice_path.resolve()) if libreoffice_path else "",
+            "PPTX_PDF_TIMEOUT": str(pdf_timeout),
+            "PPTX_PDF_RETRIES": str(pdf_retries),
+            "PPTX_POLISHER_TOGGLE": (
+                "1" if polisher_toggle else "0" if polisher_toggle is not None else ""
+            ),
+            "PPTX_POLISHER_PATH": str(polisher_path.resolve()) if polisher_path else "",
+            "PPTX_POLISHER_RULES": str(polisher_rules.resolve()) if polisher_rules else "",
+            "PPTX_POLISHER_TIMEOUT": str(polisher_timeout) if polisher_timeout else "",
+            "PPTX_POLISHER_ARGS": " ".join(polisher_args) if polisher_args else "",
+            "PPTX_POLISHER_CWD": str(polisher_cwd.resolve()) if polisher_cwd else "",
+            "PPTX_EMIT_STRUCTURE_SNAPSHOT": "1" if emit_structure_snapshot else "0",
+        }
+        if template_id:
+            stage_env["PPTX_TEMPLATE_ID"] = template_id
+        return stage_env
+
+    def _load_hook_manager(template_id: str | None) -> Any:
+        if not template_id:
+            return None
+        return load_hooks_for_template_id(template_id)
+
+    def _run_stage_hook(hook_manager: Any, stage_env: dict[str, str], template_id: str | None) -> bool:
+        if not hook_manager:
+            return True
+        executed, continue_default = hook_manager.run_stage_hook(
+            STAGE_GEN,
+            env=stage_env,
+        )
+        if executed:
+            click.echo(
+                f"[hooks] gen stage executed via external hook (template_id={template_id})"
+            )
+            return bool(continue_default)
+        return True
+
+    def _run_slide_hooks(
+        *,
+        hook_manager: Any,
+        contexts: list[Any],
+        stage_env: dict[str, str],
+        continue_default_filter: bool,
+    ) -> bool:
+        if not hook_manager:
+            return False
+        return bool(
+            hook_manager.run_slide_hooks(
+                STAGE_GEN,
+                slides=contexts,
+                env=stage_env,
+                continue_default_filter=continue_default_filter,
+                allow_fallback_context=True,
+            )
+        )
+
+    def _run_generate_job(config: GenerateCommandConfig) -> Any:
+        try:
+            return run_job_sync(
+                stage="gen",
+                func=lambda: run_generate_command(config),
+            )
+        except GenerateCommandError as exc:
+            message = str(exc)
+            if message:
+                click.echo(message, err=True)
+            raise click.exceptions.Exit(code=exc.exit_code) from exc
+
+    def _run_post_slide_hooks(
+        *,
+        hook_manager: Any,
+        stage_env: dict[str, str],
+        template_id: str | None,
+        generate_ready_path: Path,
+        output_dir: Path,
+        pptx_name: str,
+        export_pdf: bool,
+        pdf_output: str,
+    ) -> None:
+        if not hook_manager or not template_id:
+            return
+        stage_env_with_outputs = dict(stage_env)
+        pptx_path = output_dir / pptx_name
+        stage_env_with_outputs["PPTX_OUTPUT_PPTX_PATH"] = str(pptx_path.resolve())
+        if export_pdf:
+            pdf_path = output_dir / pdf_output
+            stage_env_with_outputs["PPTX_OUTPUT_PDF_PATH"] = str(pdf_path.resolve())
+        contexts = slide_contexts_from_generate_ready(generate_ready_path)
+        hook_manager.run_slide_hooks(
+            STAGE_GEN,
+            slides=contexts,
+            env=stage_env_with_outputs,
+            continue_default_filter=True,
+            allow_fallback_context=True,
+        )
+
     @click.command("gen")
     @click.argument(
         "generate_ready_path",
@@ -164,57 +290,40 @@ def create_gen_command(
     ) -> None:
         """generate_ready.json から PPTX / PDF / 監査ログを生成する。"""
 
-        hook_manager = None
         template_id = extract_template_id_from_json_file(generate_ready_path)
-        if template_id:
-            hook_manager = load_hooks_for_template_id(template_id)
-        stage_env = {
-            "PPTX_STAGE": STAGE_GEN,
-            "PPTX_GENERATE_READY_PATH": str(generate_ready_path.resolve()),
-            "PPTX_OUTPUT_DIR": str(output_dir.resolve()),
-            "PPTX_PPTX_NAME": pptx_name,
-            "PPTX_RULES_PATH": str(rules.resolve()),
-            "PPTX_EXPORT_PDF": "1" if export_pdf else "0",
-            "PPTX_PDF_MODE": pdf_mode,
-            "PPTX_PDF_OUTPUT": pdf_output,
-            "PPTX_LIBREOFFICE_PATH": str(libreoffice_path.resolve()) if libreoffice_path else "",
-            "PPTX_PDF_TIMEOUT": str(pdf_timeout),
-            "PPTX_PDF_RETRIES": str(pdf_retries),
-            "PPTX_POLISHER_TOGGLE": (
-                "1" if polisher_toggle else "0" if polisher_toggle is not None else ""
-            ),
-            "PPTX_POLISHER_PATH": str(polisher_path.resolve()) if polisher_path else "",
-            "PPTX_POLISHER_RULES": str(polisher_rules.resolve()) if polisher_rules else "",
-            "PPTX_POLISHER_TIMEOUT": str(polisher_timeout) if polisher_timeout else "",
-            "PPTX_POLISHER_ARGS": " ".join(polisher_args) if polisher_args else "",
-            "PPTX_POLISHER_CWD": str(polisher_cwd.resolve()) if polisher_cwd else "",
-            "PPTX_EMIT_STRUCTURE_SNAPSHOT": "1" if emit_structure_snapshot else "0",
-        }
-        if template_id:
-            stage_env["PPTX_TEMPLATE_ID"] = template_id
-        if hook_manager:
-            executed, continue_default = hook_manager.run_stage_hook(
-                STAGE_GEN,
-                env=stage_env,
-            )
-            if executed:
-                click.echo(
-                    f"[hooks] gen stage executed via external hook (template_id={template_id})"
-                )
-                if not continue_default:
-                    return
+        hook_manager = _load_hook_manager(template_id)
+        stage_env = _build_stage_env(
+            generate_ready_path=generate_ready_path,
+            output_dir=output_dir,
+            pptx_name=pptx_name,
+            rules=rules,
+            export_pdf=export_pdf,
+            pdf_mode=pdf_mode,
+            pdf_output=pdf_output,
+            libreoffice_path=libreoffice_path,
+            pdf_timeout=pdf_timeout,
+            pdf_retries=pdf_retries,
+            polisher_toggle=polisher_toggle,
+            polisher_path=polisher_path,
+            polisher_rules=polisher_rules,
+            polisher_timeout=polisher_timeout,
+            polisher_args=polisher_args,
+            polisher_cwd=polisher_cwd,
+            emit_structure_snapshot=emit_structure_snapshot,
+            template_id=template_id,
+        )
+
+        if not _run_stage_hook(hook_manager, stage_env, template_id):
+            return
 
         contexts = slide_contexts_from_generate_ready(generate_ready_path)
-        if hook_manager:
-            executed = hook_manager.run_slide_hooks(
-                STAGE_GEN,
-                slides=contexts,
-                env=stage_env,
-                continue_default_filter=False,
-                allow_fallback_context=True,
-            )
-            if executed:
-                return
+        if _run_slide_hooks(
+            hook_manager=hook_manager,
+            contexts=contexts,
+            stage_env=stage_env,
+            continue_default_filter=False,
+        ):
+            return
 
         config = GenerateCommandConfig(
             generate_ready_path=generate_ready_path,
@@ -235,34 +344,20 @@ def create_gen_command(
             polisher_cwd=polisher_cwd,
             emit_structure_snapshot=emit_structure_snapshot,
         )
-        try:
-            result = run_job_sync(
-                stage="gen",
-                func=lambda: run_generate_command(config),
-            )
-        except GenerateCommandError as exc:
-            message = str(exc)
-            if message:
-                click.echo(message, err=True)
-            raise click.exceptions.Exit(code=exc.exit_code) from exc
+        result = _run_generate_job(config)
 
         echo_render_outputs(result.context, result.audit_path)
 
-        if hook_manager and template_id:
-            stage_env_with_outputs = dict(stage_env)
-            pptx_path = output_dir / pptx_name
-            stage_env_with_outputs["PPTX_OUTPUT_PPTX_PATH"] = str(pptx_path.resolve())
-            if export_pdf:
-                pdf_path = output_dir / pdf_output
-                stage_env_with_outputs["PPTX_OUTPUT_PDF_PATH"] = str(pdf_path.resolve())
-            contexts = slide_contexts_from_generate_ready(generate_ready_path)
-            hook_manager.run_slide_hooks(
-                STAGE_GEN,
-                slides=contexts,
-                env=stage_env_with_outputs,
-                continue_default_filter=True,
-                allow_fallback_context=True,
-            )
+        _run_post_slide_hooks(
+            hook_manager=hook_manager,
+            stage_env=stage_env,
+            template_id=template_id,
+            generate_ready_path=generate_ready_path,
+            output_dir=output_dir,
+            pptx_name=pptx_name,
+            export_pdf=export_pdf,
+            pdf_output=pdf_output,
+        )
 
     return gen
 

--- a/tests/cli/test_cli_hook_invocations.py
+++ b/tests/cli/test_cli_hook_invocations.py
@@ -12,6 +12,7 @@ from pptx_generator.cli_commands.mapping import create_mapping_command
 from pptx_generator.cli_commands.prepare import create_prepare_command
 from pptx_generator.cli_commands.template import create_template_command
 from pptx_generator.cli_hooks.manager import SlideContext
+from pptx_generator.cli_handlers.rendering import GenerateCommandError
 
 
 class DummyHookManager:
@@ -600,6 +601,131 @@ def test_gen_invokes_slide_hooks_with_fallback(monkeypatch, tmp_path: Path) -> N
     assert post_call["continue_default_filter"] is True
 
 
+def test_gen_stage_hook_can_short_circuit(monkeypatch, tmp_path: Path) -> None:
+    called: dict[str, object] = {}
+
+    class StageOnlyHookManager(DummyHookManager):
+        def run_stage_hook(self, stage: str, env: dict[str, str]) -> tuple[bool, bool]:
+            called["env"] = dict(env)
+            return True, False
+
+        def run_slide_hooks(self, *args, **kwargs):  # noqa: ANN001
+            raise AssertionError("slide hooks should not run when stage hook short-circuits")
+
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.load_hooks_for_template_id",
+        lambda tpl: StageOnlyHookManager(),
+    )
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.extract_template_id_from_json_file",
+        lambda path: "demo_tpl",
+    )
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.slide_contexts_from_generate_ready",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("slide contexts should not build")),
+    )
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.run_generate_command",
+        lambda config: (_ for _ in ()).throw(AssertionError("should not run generate when stage hook stops")),
+    )
+
+    cmd = create_gen_command(
+        default_output_dir=tmp_path / "out",
+        default_pptx_name="out.pptx",
+        default_rules_path=_touch(tmp_path / "pipeline_rules.json"),
+        default_pdf_output="out.pdf",
+        default_pdf_timeout=10,
+        default_pdf_retries=1,
+    )
+
+    generate_ready = _touch(tmp_path / "generate_ready.json")
+    result = CliRunner().invoke(
+        cmd,
+        [
+            str(generate_ready),
+            "--output",
+            str(tmp_path / "out"),
+            "--pptx-name",
+            "out.pptx",
+            "--rules",
+            str(tmp_path / "pipeline_rules.json"),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    stage_env = called.get("env")
+    assert isinstance(stage_env, dict)
+    assert stage_env["PPTX_STAGE"] == "gen"
+    assert stage_env["PPTX_TEMPLATE_ID"] == "demo_tpl"
+
+
+def test_gen_slide_hook_can_short_circuit(monkeypatch, tmp_path: Path) -> None:
+    called: dict[str, object] = {}
+
+    class SlideShortCircuitHookManager(DummyHookManager):
+        def run_slide_hooks(  # noqa: D401
+            self,
+            stage: str,
+            *,
+            slides: list[SlideContext] | list[dict[str, Any]],
+            env: dict[str, str],
+            continue_default_filter: bool | None = None,
+            allow_fallback_context: bool = False,
+        ) -> bool:
+            called["slides"] = slides
+            called["env"] = dict(env)
+            called["continue_default_filter"] = continue_default_filter
+            called["allow_fallback_context"] = allow_fallback_context
+            return True
+
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.load_hooks_for_template_id",
+        lambda tpl: SlideShortCircuitHookManager(),
+    )
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.extract_template_id_from_json_file",
+        lambda path: "demo_tpl",
+    )
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.slide_contexts_from_generate_ready",
+        lambda *args, **kwargs: ["ctx"],
+    )
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.run_generate_command",
+        lambda config: (_ for _ in ()).throw(AssertionError("generate should not run when slide hook short-circuits")),
+    )
+
+    cmd = create_gen_command(
+        default_output_dir=tmp_path / "out",
+        default_pptx_name="out.pptx",
+        default_rules_path=_touch(tmp_path / "pipeline_rules.json"),
+        default_pdf_output="out.pdf",
+        default_pdf_timeout=10,
+        default_pdf_retries=1,
+    )
+
+    generate_ready = _touch(tmp_path / "generate_ready.json")
+    result = CliRunner().invoke(
+        cmd,
+        [
+            str(generate_ready),
+            "--output",
+            str(tmp_path / "out"),
+            "--pptx-name",
+            "out.pptx",
+            "--rules",
+            str(tmp_path / "pipeline_rules.json"),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert called["slides"] == ["ctx"]
+    assert called["continue_default_filter"] is False
+    assert called["allow_fallback_context"] is True
+
+
 def test_gen_missing_template_id_does_not_call_hooks(monkeypatch, tmp_path: Path) -> None:
     class DummyContext:
         def __init__(self) -> None:
@@ -645,6 +771,325 @@ def test_gen_missing_template_id_does_not_call_hooks(monkeypatch, tmp_path: Path
     )
 
     assert result.exit_code == 0
+
+
+def test_gen_runtime_error_propagates(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.extract_template_id_from_json_file",
+        lambda path: None,
+    )
+    monkeypatch.setattr("pptx_generator.cli_commands.gen.run_job_sync", lambda **kwargs: kwargs["func"]())
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.run_generate_command",
+        lambda config: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    cmd = create_gen_command(
+        default_output_dir=tmp_path / "out",
+        default_pptx_name="out.pptx",
+        default_rules_path=_touch(tmp_path / "pipeline_rules.json"),
+        default_pdf_output="out.pdf",
+        default_pdf_timeout=10,
+        default_pdf_retries=1,
+    )
+    generate_ready = _touch(tmp_path / "generate_ready.json")
+
+    result = CliRunner().invoke(
+        cmd,
+        [
+            str(generate_ready),
+            "--output",
+            str(tmp_path / "out"),
+            "--pptx-name",
+            "out.pptx",
+            "--rules",
+            str(tmp_path / "pipeline_rules.json"),
+        ],
+        catch_exceptions=True,
+    )
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, RuntimeError)
+    assert "boom" in str(result.exception)
+
+
+def test_gen_post_hook_not_called_on_generate_command_error(monkeypatch, tmp_path: Path) -> None:
+    hook_manager = DummyHookManager()
+    monkeypatch.setattr("pptx_generator.cli_commands.gen.load_hooks_for_template_id", lambda tpl: hook_manager)
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.extract_template_id_from_json_file",
+        lambda path: "demo_tpl",
+    )
+    monkeypatch.setattr("pptx_generator.cli_commands.gen.run_job_sync", lambda **kwargs: kwargs["func"]())
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.run_generate_command",
+        lambda config: (_ for _ in ()).throw(GenerateCommandError("fail", exit_code=7)),
+    )
+
+    cmd = create_gen_command(
+        default_output_dir=tmp_path / "out",
+        default_pptx_name="out.pptx",
+        default_rules_path=_touch(tmp_path / "pipeline_rules.json"),
+        default_pdf_output="out.pdf",
+        default_pdf_timeout=10,
+        default_pdf_retries=1,
+    )
+    generate_ready = _touch(tmp_path / "generate_ready.json")
+
+    result = CliRunner().invoke(
+        cmd,
+        [
+            str(generate_ready),
+            "--output",
+            str(tmp_path / "out"),
+            "--pptx-name",
+            "out.pptx",
+            "--rules",
+            str(tmp_path / "pipeline_rules.json"),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 7
+    assert "fail" in result.output
+    # pre slide hook runs once, post slide hook should not run
+    assert len(hook_manager.slide_calls) == 1
+    assert hook_manager.slide_calls[0]["continue_default_filter"] is False
+
+
+def test_gen_post_hook_not_called_on_runtime_error(monkeypatch, tmp_path: Path) -> None:
+    hook_manager = DummyHookManager()
+    monkeypatch.setattr("pptx_generator.cli_commands.gen.load_hooks_for_template_id", lambda tpl: hook_manager)
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.extract_template_id_from_json_file",
+        lambda path: "demo_tpl",
+    )
+    monkeypatch.setattr("pptx_generator.cli_commands.gen.run_job_sync", lambda **kwargs: kwargs["func"]())
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.run_generate_command",
+        lambda config: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    cmd = create_gen_command(
+        default_output_dir=tmp_path / "out",
+        default_pptx_name="out.pptx",
+        default_rules_path=_touch(tmp_path / "pipeline_rules.json"),
+        default_pdf_output="out.pdf",
+        default_pdf_timeout=10,
+        default_pdf_retries=1,
+    )
+    generate_ready = _touch(tmp_path / "generate_ready.json")
+
+    result = CliRunner().invoke(
+        cmd,
+        [
+            str(generate_ready),
+            "--output",
+            str(tmp_path / "out"),
+            "--pptx-name",
+            "out.pptx",
+            "--rules",
+            str(tmp_path / "pipeline_rules.json"),
+        ],
+        catch_exceptions=True,
+    )
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, RuntimeError)
+    assert len(hook_manager.slide_calls) == 1
+    assert hook_manager.slide_calls[0]["continue_default_filter"] is False
+
+
+def test_gen_post_hook_without_pdf_sets_only_pptx_path(monkeypatch, tmp_path: Path) -> None:
+    hook_manager = DummyHookManager()
+    monkeypatch.setattr("pptx_generator.cli_commands.gen.load_hooks_for_template_id", lambda tpl: hook_manager)
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.extract_template_id_from_json_file",
+        lambda path: "demo_tpl",
+    )
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.slide_contexts_from_generate_ready",
+        lambda *args, **kwargs: ["ctx"],
+    )
+
+    class DummyContext:
+        def __init__(self) -> None:
+            self.artifacts = {}
+
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.run_generate_command",
+        lambda config: type("R", (), {"context": DummyContext(), "audit_path": tmp_path / 'audit.json'})(),
+    )
+    monkeypatch.setattr("pptx_generator.cli_commands.gen.run_job_sync", lambda **kwargs: kwargs["func"]())
+    contexts_calls = []
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.slide_contexts_from_generate_ready",
+        lambda *args, **kwargs: contexts_calls.append("called") or ["ctx"],
+    )
+
+    cmd = create_gen_command(
+        default_output_dir=tmp_path / "out",
+        default_pptx_name="out.pptx",
+        default_rules_path=_touch(tmp_path / "pipeline_rules.json"),
+        default_pdf_output="out.pdf",
+        default_pdf_timeout=10,
+        default_pdf_retries=1,
+    )
+
+    generate_ready = _touch(tmp_path / "generate_ready.json")
+    result = CliRunner().invoke(
+        cmd,
+        [
+            str(generate_ready),
+            "--output",
+            str(tmp_path / "out"),
+            "--pptx-name",
+            "out.pptx",
+            "--rules",
+            str(tmp_path / "pipeline_rules.json"),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    # post hook should be the last slide hook invocation
+    env = hook_manager.slide_calls[-1]["env"]
+    assert "PPTX_OUTPUT_PPTX_PATH" in env
+    assert "PPTX_OUTPUT_PDF_PATH" not in env
+    assert contexts_calls.count("called") == 2
+
+
+def test_gen_post_hook_with_pdf_sets_pdf_path(monkeypatch, tmp_path: Path) -> None:
+    hook_manager = DummyHookManager()
+    monkeypatch.setattr("pptx_generator.cli_commands.gen.load_hooks_for_template_id", lambda tpl: hook_manager)
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.extract_template_id_from_json_file",
+        lambda path: "demo_tpl",
+    )
+    contexts_calls = []
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.slide_contexts_from_generate_ready",
+        lambda *args, **kwargs: contexts_calls.append("called") or ["ctx"],
+    )
+
+    class DummyContext:
+        def __init__(self) -> None:
+            self.artifacts = {}
+
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.run_generate_command",
+        lambda config: type("R", (), {"context": DummyContext(), "audit_path": tmp_path / 'audit.json'})(),
+    )
+    monkeypatch.setattr("pptx_generator.cli_commands.gen.run_job_sync", lambda **kwargs: kwargs["func"]())
+
+    cmd = create_gen_command(
+        default_output_dir=tmp_path / "out",
+        default_pptx_name="out.pptx",
+        default_rules_path=_touch(tmp_path / "pipeline_rules.json"),
+        default_pdf_output="out.pdf",
+        default_pdf_timeout=10,
+        default_pdf_retries=1,
+    )
+
+    generate_ready = _touch(tmp_path / "generate_ready.json")
+    result = CliRunner().invoke(
+        cmd,
+        [
+            str(generate_ready),
+            "--output",
+            str(tmp_path / "out"),
+            "--pptx-name",
+            "out.pptx",
+            "--rules",
+            str(tmp_path / "pipeline_rules.json"),
+            "--export-pdf",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    env = hook_manager.slide_calls[-1]["env"]
+    assert "PPTX_OUTPUT_PPTX_PATH" in env
+    assert "PPTX_OUTPUT_PDF_PATH" in env
+    assert contexts_calls.count("called") == 2
+
+
+def test_gen_generate_command_error_outputs_message(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.extract_template_id_from_json_file",
+        lambda path: None,
+    )
+    monkeypatch.setattr("pptx_generator.cli_commands.gen.run_job_sync", lambda **kwargs: kwargs["func"]())
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.run_generate_command",
+        lambda config: (_ for _ in ()).throw(GenerateCommandError("polisher error", exit_code=12)),
+    )
+
+    cmd = create_gen_command(
+        default_output_dir=tmp_path / "out",
+        default_pptx_name="out.pptx",
+        default_rules_path=_touch(tmp_path / "pipeline_rules.json"),
+        default_pdf_output="out.pdf",
+        default_pdf_timeout=10,
+        default_pdf_retries=1,
+    )
+    generate_ready = _touch(tmp_path / "generate_ready.json")
+
+    result = CliRunner().invoke(
+        cmd,
+        [
+            str(generate_ready),
+            "--output",
+            str(tmp_path / "out"),
+            "--pptx-name",
+            "out.pptx",
+            "--rules",
+            str(tmp_path / "pipeline_rules.json"),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 12
+    assert "polisher error" in result.output
+
+
+def test_gen_generate_command_error_with_empty_message(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.extract_template_id_from_json_file",
+        lambda path: None,
+    )
+    monkeypatch.setattr("pptx_generator.cli_commands.gen.run_job_sync", lambda **kwargs: kwargs["func"]())
+    monkeypatch.setattr(
+        "pptx_generator.cli_commands.gen.run_generate_command",
+        lambda config: (_ for _ in ()).throw(GenerateCommandError("", exit_code=9)),
+    )
+
+    cmd = create_gen_command(
+        default_output_dir=tmp_path / "out",
+        default_pptx_name="out.pptx",
+        default_rules_path=_touch(tmp_path / "pipeline_rules.json"),
+        default_pdf_output="out.pdf",
+        default_pdf_timeout=10,
+        default_pdf_retries=1,
+    )
+    generate_ready = _touch(tmp_path / "generate_ready.json")
+
+    result = CliRunner().invoke(
+        cmd,
+        [
+            str(generate_ready),
+            "--output",
+            str(tmp_path / "out"),
+            "--pptx-name",
+            "out.pptx",
+            "--rules",
+            str(tmp_path / "pipeline_rules.json"),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 9
+    assert result.output == ""
 
 
 def test_template_invokes_slide_hooks_with_fallback(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## 概要
- gen コマンドのフック経路を関数分割し、認知的複雑度を下げつつ異常系ハンドリングを明確化。
- stage/slide hook のショートサーキット挙動と post-hook 環境変数付与を整理し、出口コード・メッセージの一貫性を確保。

## 関連リンク
- Issue Close: #488
- ToDo: なし（今回作成不要指示）
- ノート／設計資料: なし

## 変更内容
- `gen` エントリで stage env 構築、hook 実行、ジョブ実行、後処理をヘルパー関数に分割。
- stage/slide hook ショートサーキット時の早期 return と post-hook 環境変数の付与を明示化。
- `tests/cli/test_cli_hook_invocations.py` に異常系・ショートサーキット・環境変数・エラーメッセージ有無を検証するケースを追加。

## ユーザー影響
- gen 実行時の hook 連携とエラーメッセージ/終了コードが安定し、PDF/PPTX パス付与も一貫化。
- 確認方法: `uv run --extra dev pytest` の成功と diff-cover で差分カバレッジ 80% 超を確認。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest` / `uv tool run diff-cover coverage.xml --compare-branch origin/main`
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: なし
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した（該当 ToDo なし）
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている（今回対象外）
- [x] Issue 自動クローズ用に `Close #488` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した（未実施）
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した（影響なしのため更新不要）
- [ ] 生成物（PDF など）がある場合は添付または参照先を明記した（該当なし）
- [x] PR 本文中の `Close #<番号>` や `docs/todo/…` などのプレースホルダをすべて実際の値に置き換えた