### PR TITLE
fix: RM-000 text edit complexity

### DIFF
--- a/src/pptx_generator/pipeline/text_edit.py
+++ b/src/pptx_generator/pipeline/text_edit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, List
 
@@ -59,81 +60,8 @@ def apply_shape_text_edits(
     presentation = Presentation(pptx_path)
     output_path = Path(output_path) if output_path is not None else pptx_path
 
-    normalized: list[dict[str, object]] = []
-    for edit in edits:
-        if not isinstance(edit, dict):
-            continue
-        if not edit.get("edit", True):
-            continue
-        shape_id = edit.get("shape_id")
-        contents = edit.get("contents")
-        if shape_id is None or contents is None:
-            continue
-        try:
-            shape_id_int = int(shape_id)
-        except (TypeError, ValueError):
-            continue
-        try:
-            slide_idx = int(edit.get("slide_index")) if edit.get("slide_index") is not None else None
-        except (TypeError, ValueError):
-            slide_idx = None
-        name_val = edit.get("name")
-        normalized.append(
-            {
-                "shape_id": shape_id_int,
-                "slide_index": slide_idx,
-                "name": str(name_val) if name_val is not None else None,
-                "contents": str(contents),
-            }
-        )
-
-    applied = 0
-    missing: list[str] = []
-
-    for edit in normalized:
-        target_slide = edit.get("slide_index")
-        target_id = edit["shape_id"]
-        target_name = edit.get("name")
-        new_text = edit["contents"]
-        found = False
-
-        for slide_index, slide in enumerate(presentation.slides):
-            if target_slide is not None and slide_index != target_slide:
-                continue
-            for shape in _iter_shapes(slide.shapes):
-                if getattr(shape, "shape_id", None) != target_id:
-                    continue
-                if target_name is not None and target_name != getattr(shape, "name", None):
-                    continue
-                if hasattr(shape, "text_frame"):
-                    overwrite_text_frame_preserving_style(shape.text_frame, new_text)
-                    applied += 1
-                    found = True
-                    break
-            if found:
-                break
-            for shape in slide.shapes:
-                if not getattr(shape, "has_table", False):
-                    continue
-                for row_idx, row in enumerate(getattr(shape.table, "rows", [])):
-                    for col_idx, cell in enumerate(getattr(row, "cells", [])):
-                        cell_id = table_cell_shape_id(int(shape.shape_id), row_idx, col_idx)
-                        if cell_id != target_id:
-                            continue
-                        if target_name is not None and target_name != getattr(shape, "name", None):
-                            continue
-                        overwrite_text_frame_preserving_style(cell.text_frame, new_text)
-                        applied += 1
-                        found = True
-                        break
-                    if found:
-                        break
-                if found:
-                    break
-
-        if not found:
-            missing.append(f"{target_slide}:{target_id}" if target_slide is not None else str(target_id))
-
+    normalized = _normalize_edits(edits)
+    applied, missing = _apply_edits_to_presentation(presentation, normalized)
     presentation.save(output_path)
     return applied, missing
 
@@ -296,6 +224,89 @@ def _edit_applied(target_shape_id: int, presentation, target_slide_index: int | 
                             if target_name is None or target_name == getattr(shape, "name", None):
                                 return True
     return False
+
+
+@dataclass
+class _NormalizedEdit:
+    shape_id: int
+    slide_index: int | None
+    name: str | None
+    contents: str
+
+
+def _normalize_edits(edits: Iterable[dict[str, object]]) -> list[_NormalizedEdit]:
+    normalized: list[_NormalizedEdit] = []
+    for edit in edits:
+        if not isinstance(edit, dict):
+            continue
+        if not edit.get("edit", True):
+            continue
+        shape_id = edit.get("shape_id")
+        contents = edit.get("contents")
+        if shape_id is None or contents is None:
+            continue
+        try:
+            shape_id_int = int(shape_id)
+        except (TypeError, ValueError):
+            continue
+        try:
+            slide_idx = int(edit.get("slide_index")) if edit.get("slide_index") is not None else None
+        except (TypeError, ValueError):
+            slide_idx = None
+        name_val = edit.get("name")
+        normalized.append(
+            _NormalizedEdit(
+                shape_id=shape_id_int,
+                slide_index=slide_idx,
+                name=str(name_val) if name_val is not None else None,
+                contents=str(contents),
+            )
+        )
+    return normalized
+
+
+def _apply_edits_to_presentation(
+    presentation: PptxPresentation, edits: list[_NormalizedEdit]
+) -> tuple[int, list[str]]:
+    applied = 0
+    missing: list[str] = []
+    for edit in edits:
+        if _apply_single_edit(presentation, edit):
+            applied += 1
+        else:
+            missing.append(_format_missing_key(edit))
+    return applied, missing
+
+
+def _apply_single_edit(presentation: PptxPresentation, edit: _NormalizedEdit) -> bool:
+    for slide_index, slide in enumerate(presentation.slides):
+        if edit.slide_index is not None and slide_index != edit.slide_index:
+            continue
+        for shape_id, shape_name, text_frame in _iter_slide_text_frames(slide):
+            if shape_id != edit.shape_id:
+                continue
+            if edit.name is not None and edit.name != shape_name:
+                continue
+            overwrite_text_frame_preserving_style(text_frame, edit.contents)
+            return True
+    return False
+
+
+def _iter_slide_text_frames(slide):
+    for shape in _iter_shapes(slide.shapes):
+        shape_id = getattr(shape, "shape_id", None)
+        shape_name = getattr(shape, "name", None)
+        if getattr(shape, "has_text_frame", False):
+            yield shape_id, shape_name, shape.text_frame
+        if getattr(shape, "has_table", False):
+            for row_idx, row in enumerate(getattr(shape.table, "rows", [])):
+                for col_idx, cell in enumerate(getattr(row, "cells", [])):
+                    cell_id = table_cell_shape_id(int(shape.shape_id), row_idx, col_idx)
+                    yield cell_id, shape_name, cell.text_frame
+
+
+def _format_missing_key(edit: _NormalizedEdit) -> str:
+    return f"{edit.slide_index}:{edit.shape_id}" if edit.slide_index is not None else str(edit.shape_id)
 
 
 __all__ = ["overwrite_text_frame_preserving_style", "apply_shape_text_edits", "generate_edits_template"]

--- a/tests/pipeline/test_text_edit.py
+++ b/tests/pipeline/test_text_edit.py
@@ -10,6 +10,9 @@ from pptx_generator.pipeline.text_edit import (
     apply_shape_text_edits,
     generate_edits_template,
     overwrite_text_frame_preserving_style,
+    _apply_single_edit,
+    _iter_slide_text_frames,
+    _normalize_edits,
 )
 from pptx_generator.pipeline.analyzer.snapshot import table_cell_shape_id
 
@@ -258,3 +261,124 @@ def test_pptx_edit_cli_same_name_multiple_runs(tmp_path, monkeypatch) -> None:
     assert first_output.exists()
     outputs = list(out_root.rglob("input_cli_multi.pptx"))
     assert outputs == [first_output]
+
+
+def test_normalize_edits_filters_and_preserves_indices() -> None:
+    normalized = _normalize_edits(
+        [
+            {"shape_id": "10", "contents": "ok", "slide_index": "2"},
+            {"shape_id": "11", "contents": "keep", "slide_index": -1},
+            {"shape_id": None, "contents": "skip"},
+            {"shape_id": "bad", "contents": "skip"},
+            {"shape_id": "12", "contents": "skip", "edit": False},
+            "not a dict",
+        ]
+    )
+
+    assert [n.shape_id for n in normalized] == [10, 11]
+    assert normalized[0].slide_index == 2
+    assert normalized[1].slide_index == -1  # 負値は維持されることを確認
+
+
+def test_apply_single_edit_requires_name_exact_match(tmp_path) -> None:
+    pptx_path = tmp_path / "name_case.pptx"
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    shape = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(4), Inches(1))
+    shape.name = "ExactName"
+    shape.text = "before"
+    presentation.save(pptx_path)
+
+    edit = _normalize_edits(
+        [{"shape_id": shape.shape_id, "contents": "after", "name": "exactname"}]
+    )[0]
+
+    assert _apply_single_edit(presentation, edit) is False
+
+
+def test_apply_single_edit_skips_when_slide_index_not_found(tmp_path) -> None:
+    pptx_path = tmp_path / "missing_slide.pptx"
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    shape = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(4), Inches(1))
+    shape.text = "before"
+    presentation.save(pptx_path)
+
+    edit = _normalize_edits(
+        [{"shape_id": shape.shape_id, "contents": "after", "slide_index": 5}]
+    )[0]
+
+    assert _apply_single_edit(presentation, edit) is False
+
+
+def test_iter_slide_text_frames_includes_group_and_table(monkeypatch) -> None:
+    class DummyText:
+        def __init__(self, shape_id, name):
+            self.shape_id = shape_id
+            self.name = name
+            self.has_text_frame = True
+            self.text_frame = f"text-{shape_id}"
+            self.has_table = False
+
+    class DummyTable:
+        def __init__(self, shape_id, name):
+            self.shape_id = shape_id
+            self.name = name
+            self.has_text_frame = False
+            self.has_table = True
+            self.table = type(
+                "T",
+                (),
+                {
+                    "rows": [
+                        type("R", (), {"cells": [type("C", (), {"text_frame": "cell-tf"})]})
+                    ]
+                },
+            )()
+
+    class DummyGroup:
+        def __init__(self, shapes):
+            self.shapes = shapes
+
+    inner_text = DummyText(101, "inner")
+    group_shape = DummyGroup([inner_text])
+    table_shape = DummyTable(201, "tbl")
+    slide = type("S", (), {"shapes": [group_shape, table_shape]})
+
+    def fake_iter_shapes(shapes):
+        for shape in shapes:
+            yield shape
+            if hasattr(shape, "shapes"):
+                yield from shape.shapes
+
+    monkeypatch.setattr("pptx_generator.pipeline.text_edit._iter_shapes", fake_iter_shapes)
+
+    frames = list(_iter_slide_text_frames(slide))
+
+    text_entries = [(sid, name) for sid, name, _tf in frames if isinstance(_tf, str)]
+    assert (101, "inner") in text_entries
+    assert any(sid == table_cell_shape_id(201, 0, 0) for sid, _name, _tf in frames)
+
+
+def test_apply_shape_text_edits_handles_mixed_text_and_table(tmp_path) -> None:
+    pptx_path = tmp_path / "mixed.pptx"
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    textbox = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(2), Inches(1))
+    textbox.text = "box"
+    table_shape = slide.shapes.add_table(1, 1, Inches(1), Inches(2), Inches(2), Inches(1))
+    table_id = table_cell_shape_id(int(table_shape.shape_id), 0, 0)
+    presentation.save(pptx_path)
+
+    edits = [
+        {"shape_id": table_id, "contents": "table-new"},
+        {"shape_id": textbox.shape_id, "contents": "text-new"},
+    ]
+
+    applied, missing = apply_shape_text_edits(pptx_path, edits)
+
+    assert applied == 2
+    assert missing == []
+    reloaded = Presentation(pptx_path)
+    assert reloaded.slides[0].shapes[0].text == "text-new"
+    assert reloaded.slides[0].shapes[1].table.cell(0, 0).text == "table-new"


### PR DESCRIPTION
## 概要
- text_edit.py の apply_shape_text_edits の認知的複雑度を分割で削減し、動作を維持したままメンテ性を向上。
- 入力正規化と適用処理を関数分割し、グループ/テーブルセル対応を整理。

## 関連リンク
- Issue Close: #531
- ToDo: なし（ユーザー指示により未作成）
- ノート／設計資料: なし

## 変更内容
- apply_shape_text_edits を正規化・適用処理に分割し、補助関数 (_normalize_edits, _apply_single_edit など) を追加。
- グループ内テキスト/テーブルセルを含む取得ヘルパーを追加し、欠落パスを整理。
- 入力正規化・名前一致・スライド指定ミス・グループ/テーブルセル・混在適用のテストを追加。

## ユーザー影響
- CLI/パイプラインの挙動は不変。複雑度低減により後続変更時のリスクを抑制。
- 影響確認: テキスト・テーブル置換を含む edits JSON を適用し、出力 PPTX が期待どおり更新されること。

## 動作確認
- [x] ローカルで想定テストを実行した
  - 実行コマンド: `uv run --extra dev pytest tests/pipeline/test_text_edit.py --cov=src/pptx_generator/pipeline/text_edit.py --cov-report=xml`
- [ ] 追加の手動確認（スクリーンショット、生成物チェックなど）を実施した
  - 添付ファイル／確認方法: なし
- [x] 必要なレビュー観点を満たしている

## チェックリスト
- [ ] 該当 ToDo のチェックボックスとメモを最新化した
- [ ] ロードマップ（docs/roadmap/roadmap.md）が最新状態になっている
- [x] Issue 自動クローズ用に `Close #<番号>` を PR 本文へ記載した
- [ ] Issue に進捗コメント（またはクローズコメント）を残した
- [x] 影響範囲を確認し、必要なドキュメント・サンプルを更新した
- [ ] 生成物（PDF など）がある場合は添付または参照先を明記した
- [x] PR 本文中の `Close #<番号>` や `docs/todo/…` などのプレースホルダをすべて実際の値に置き換えた